### PR TITLE
Implement UID2Client and improve unit test coverage

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -30,4 +30,5 @@ android {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 }

--- a/sdk/src/main/java/com/uid2/sdk/UID2Client.kt
+++ b/sdk/src/main/java/com/uid2/sdk/UID2Client.kt
@@ -1,0 +1,80 @@
+package com.uid2.sdk
+
+import com.uid2.sdk.network.DataEnvelope
+import com.uid2.sdk.network.NetworkRequest
+import com.uid2.sdk.network.NetworkRequestType
+import com.uid2.sdk.network.NetworkSession
+import com.uid2.sdk.network.RefreshPackage
+import com.uid2.sdk.network.RefreshResponse
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * This class is responsible for refreshing the identity, using a provided refresh token. The payload response will be
+ * encrypted, so also is provided a key to allow decryption.
+ */
+class UID2Client(
+    private val apiUrl: String,
+    private val session: NetworkSession,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    // The refresh endpoint is built from the given API root, along with our known refresh path appended. If the
+    // consumer has incorrectly configured the SDK, it's possible this could be null.
+    private val apiRefreshUrl: URL? by lazy {
+        runCatching {
+            URL(URI(apiUrl)
+                .resolve(API_REFRESH_PATH)
+                .toString()
+            )
+        }.getOrNull()
+    }
+
+    @Throws(
+        InvalidApiUrlException::class,
+        RefreshTokenException::class,
+        PayloadDecryptException::class,
+        InvalidPayloadException::class
+    )
+    suspend fun refreshIdentity(
+        refreshToken: String,
+        refreshResponseKey: String,
+    ): RefreshPackage = withContext(ioDispatcher) {
+
+        // Check to make sure we have a valid endpoint to hit.
+        val url = apiRefreshUrl ?: throw InvalidApiUrlException()
+
+        // Build the request to refresh the token.
+        val request = NetworkRequest(
+            NetworkRequestType.POST,
+            mapOf(
+                "X-UID2-Client-Version" to "Android-0.1",
+                "Content-Type" to "application/x-www-form-urlencoded"
+            ),
+            refreshToken
+        )
+
+        // Attempt to make the request via the provided NetworkSession.
+        val response = session.loadData(url, request)
+        if (response.code != HttpURLConnection.HTTP_OK) {
+            throw RefreshTokenException(response.code)
+        }
+
+        // The response should be an encrypted payload. Let's attempt to decrypt it using the key we were provided.
+        val payload = DataEnvelope.decrypt(refreshResponseKey, response.data, true)
+            ?: throw PayloadDecryptException()
+
+        // The decrypted payload should be JSON which we can parse.
+        val refreshResponse = RefreshResponse.fromJson(JSONObject(String(payload, Charsets.UTF_8)))
+        return@withContext refreshResponse?.toRefreshPackage() ?: throw InvalidPayloadException()
+    }
+
+    private companion object {
+        // The relative path of the API's refresh endpoint
+        const val API_REFRESH_PATH = "/v2/token/refresh"
+    }
+}

--- a/sdk/src/main/java/com/uid2/sdk/UID2Exception.kt
+++ b/sdk/src/main/java/com/uid2/sdk/UID2Exception.kt
@@ -1,0 +1,26 @@
+package com.uid2.sdk
+
+/**
+ * Base class for all custom exceptions reported by the UID2 SDK.
+ */
+open class UID2Exception(message: String? = null, cause: Throwable? = null): Exception(message, cause)
+
+/**
+ * The configured API URL is invalid.
+ */
+class InvalidApiUrlException: UID2Exception()
+
+/**
+ * The attempt to refresh the token/identity via the API failed.
+ */
+class RefreshTokenException(val statusCode: Int): UID2Exception()
+
+/**
+ * The encrypted payload could not be decrypted successfully.
+ */
+class PayloadDecryptException: UID2Exception()
+
+/**
+ * The decrypted payload appears invalid.
+ */
+class InvalidPayloadException: UID2Exception()

--- a/sdk/src/main/java/com/uid2/sdk/network/NetworkSession.kt
+++ b/sdk/src/main/java/com/uid2/sdk/network/NetworkSession.kt
@@ -11,26 +11,31 @@ enum class NetworkRequestType {
 }
 
 /**
- * A class which represents a network request. This could include a number of headers to be used
- * within the request, along with if the request is a POST, some additional data which needs to be
- * written to the connection.
+ * A class which represents a network request. This could include a number of headers to be used within the request,
+ * along with if the request is a POST, some additional data which needs to be written to the connection.
  */
 data class NetworkRequest(
     val type: NetworkRequestType,
     val headers: Map<String, String> = mapOf(),
-    val data: Map<String, Any>? = null
+    val data: String? = null
 )
 
 /**
- * This interface controls all network access. A default implementation will be included within the
- * library, but consumers can also choose to implement it to leverage their own networking code
- * (e.g. OkHttp).
+ * A class which represents a network response. This will include the HTTP status code, as well as any response data.
+ */
+data class NetworkResponse(
+    val code: Int,
+    val data: String = ""
+)
+
+/**
+ * This interface controls all network access. A default implementation will be included within the library, but
+ * consumers can also choose to implement it to leverage their own networking code (e.g. OkHttp).
  */
 interface NetworkSession {
 
     /**
-     * Requests the given URL with the details provided in the request. Any response data will be
-     * returned in a map of key/value pairs.
+     * Requests the given URL with the details provided in the request.
      */
-    fun loadData(url: URL, request: NetworkRequest): Map<String, Any>
+    fun loadData(url: URL, request: NetworkRequest): NetworkResponse
 }

--- a/sdk/src/main/java/com/uid2/sdk/network/RefreshResponse.kt
+++ b/sdk/src/main/java/com/uid2/sdk/network/RefreshResponse.kt
@@ -58,6 +58,11 @@ data class RefreshResponse(
             val body = json.optJSONObject("body")?.let { UID2Identity.fromJson(it) }
             val message = json.opt("message")?.toString()
 
+            // Check that if we've successfully refreshed, that we have a valid UID2Identity.
+            if (status == SUCCESS && body == null) {
+                return null
+            }
+
             return RefreshResponse(
                 body,
                 status,

--- a/sdk/src/test/assets/test-data/identity-valid.json
+++ b/sdk/src/test/assets/test-data/identity-valid.json
@@ -1,0 +1,8 @@
+{
+    "advertising_token": "token",
+    "refresh_token": "refresh",
+    "identity_expires": 123456,
+    "refresh_expires": 654321,
+    "refresh_from": 321,
+    "refresh_response_key": "response key"
+}

--- a/sdk/src/test/assets/test-data/refresh-token-200-expired-decrypted.json
+++ b/sdk/src/test/assets/test-data/refresh-token-200-expired-decrypted.json
@@ -1,0 +1,3 @@
+{
+  "status": "expired_token"
+}

--- a/sdk/src/test/java/com/uid2/sdk/UID2ClientTest.kt
+++ b/sdk/src/test/java/com/uid2/sdk/UID2ClientTest.kt
@@ -1,0 +1,133 @@
+package com.uid2.sdk
+
+import com.uid2.sdk.data.IdentityStatus
+import com.uid2.sdk.data.TestData
+import com.uid2.sdk.data.UID2Identity
+import com.uid2.sdk.network.NetworkResponse
+import com.uid2.sdk.network.NetworkSession
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class UID2ClientTest {
+    private val networkSession: NetworkSession = mock()
+
+    private val url = "https://test.dev"
+    private val refreshToken = "RefreshToken"
+    private val refreshKey = "RefreshKey"
+
+    @Test
+    fun `test invalid api url`() {
+        val client = UID2Client(
+            "this is not a url",
+            networkSession
+        )
+
+        // Verify that when we have configured the client with an invalid URL, that it throws the appropriate exception
+        // when we try to refresh the Identity.
+        assertThrows(InvalidApiUrlException::class.java) {
+            runBlocking { client.refreshIdentity(refreshToken, refreshKey) }
+        }
+    }
+
+
+    @Test
+    fun `test network failure`() {
+        val client = UID2Client(
+            url,
+            networkSession
+        )
+
+        // Configure the network session to report a failure.
+        whenever(networkSession.loadData(any(), any())).thenReturn(NetworkResponse(400))
+
+        // Verify that when a network failure occurs, the appropriate exception is thrown.
+        assertThrows(RefreshTokenException::class.java) {
+            runBlocking { client.refreshIdentity(refreshToken, refreshKey) }
+        }
+    }
+
+    @Test
+    fun `test invalid data failure`() {
+        val client = UID2Client(
+            url,
+            networkSession
+        )
+
+        whenever(networkSession.loadData(any(), any())).thenReturn(
+            NetworkResponse(200, "This is not encrypted")
+        )
+
+        // Verify that when an unexpected response is returned, the appropriate exception is thrown.
+        assertThrows(PayloadDecryptException::class.java) {
+            runBlocking { client.refreshIdentity(refreshToken, refreshKey) }
+        }
+    }
+
+    @Test
+    fun `test invalid data key`() {
+        val client = UID2Client(
+            url,
+            networkSession
+        )
+
+        whenever(networkSession.loadData(any(), any())).thenReturn(
+            NetworkResponse(200, TestData.REFRESH_TOKEN_SUCCESS_ENCRYPTED)
+        )
+
+        // Verify that when an unexpected response is returned, the appropriate exception is thrown.
+        assertThrows(PayloadDecryptException::class.java) {
+            runBlocking { client.refreshIdentity(refreshToken, "This is not a key") }
+        }
+    }
+
+    @Test
+    fun `test successful refresh`() = runBlocking {
+        val client = UID2Client(
+            url,
+            networkSession
+        )
+
+        // Configure the network session to return a valid (encrypted) payload.
+        whenever(networkSession.loadData(any(), any())).thenReturn(
+            NetworkResponse(200, TestData.REFRESH_TOKEN_SUCCESS_ENCRYPTED)
+        )
+
+        // Verify that the payload was successfully decrypted, and parsed.
+        val identity = client.refreshIdentity(refreshToken, TestData.REFRESH_TOKEN_ENCRYPTED_SUCCESS_KEY)
+        assertEquals(IdentityStatus.REFRESHED, identity.status)
+
+        // Verify that the returned package has an identity that matches what we included in the body of the response.
+        val expectedIdentity = JSONObject(TestData.REFRESH_TOKEN_SUCCESS_DECRYPTED).getJSONObject("body").let {
+            UID2Identity.fromJson(it)
+        }
+        assertEquals(expectedIdentity, identity.identity)
+    }
+
+    @Test
+    fun `test successful optout`() = runBlocking {
+        val client = UID2Client(
+            url,
+            networkSession
+        )
+
+        // Configure the network session to return a valid (encrypted) payload.
+        whenever(networkSession.loadData(any(), any())).thenReturn(
+            NetworkResponse(200, TestData.REFRESH_TOKEN_OPT_OUT_ENCRYPTED)
+        )
+
+        // Verify that the payload was successfully decrypted, and parsed.
+        val identity = client.refreshIdentity(refreshToken, TestData.REFRESH_TOKEN_ENCRYPTED_OPT_OUT_KEY)
+        assertEquals(IdentityStatus.OPT_OUT, identity.status)
+        assertNull(identity.identity)
+    }
+}

--- a/sdk/src/test/java/com/uid2/sdk/data/TestData.kt
+++ b/sdk/src/test/java/com/uid2/sdk/data/TestData.kt
@@ -4,11 +4,8 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStream
 
 object TestData {
-    // A valid json representation, but missing the required "refresh_response_key" parameter.
-    const val INVALID_IDENTITY = "{\"advertising_token\":\"token\",\"refresh_token\":\"refresh\",\"identity_expires\":123456,\"refresh_from\":321,\"refresh_expires\":654321}"
-
     // A valid, yet made up, json representation.
-    const val VALID_IDENTITY = "{\"advertising_token\":\"token\",\"refresh_token\":\"refresh\",\"identity_expires\":123456,\"refresh_from\":321,\"refresh_expires\":654321,\"refresh_response_key\":\"response key\"}"
+    val VALID_IDENTITY = ResourceHelper.loadString("test-data/identity-valid.json")
     const val VALID_IDENTITY_AD_TOKEN = "token"
     const val VALID_IDENTITY_REFRESH_TOKEN = "refresh"
     const val VALID_IDENTITY_EXPIRES = 123456L
@@ -16,15 +13,8 @@ object TestData {
     const val VALID_IDENTITY_REFRESH_EXPIRES = 654321L
     const val VALID_IDENTITY_REFRESH_RESPONSE_KEY = "response key"
 
-    // A valid json representation, but missing the required "status" parameter.
-    const val INVALID_REFRESH = "{\"body\":{\"advertising_token\":\"token\",\"refresh_token\":\"refresh\",\"identity_expires\":123456,\"refresh_from\":321,\"refresh_expires\":654321,\"refresh_response_key\":\"response key\"}}"
-
-    // A valid, yet made up, json representation. The body contains the VALID_IDENTITY example shared above.
-    const val VALID_REFRESH = "{\"body\":{\"advertising_token\":\"token\",\"refresh_token\":\"refresh\",\"identity_expires\":123456,\"refresh_from\":321,\"refresh_expires\":654321,\"refresh_response_key\":\"response key\"},\"status\":\"success\"}"
-    const val VALID_REFRESH_STATUS = "success"
-
-    const val VALID_REFRESH_OPT_OUT = "{\"status\":\"optout\",\"message\":\"User opted out\"}"
-    const val VALID_REFRESH_EXPIRED_TOKEN = "{\"status\":\"expired_token\",\"message\":\"Token expired\"}"
+    val VALID_REFRESH_OPT_OUT = ResourceHelper.loadString("test-data/refresh-token-200-optout-decrypted.json")
+    val VALID_REFRESH_EXPIRED_TOKEN = ResourceHelper.loadString("test-data/refresh-token-200-expired-decrypted.json")
 
     // A Base64 encrypted refresh response that reports a status of "optout"
     val REFRESH_TOKEN_OPT_OUT_ENCRYPTED = ResourceHelper.loadString("test-data/refresh-token-200-optout-encrypted.txt")
@@ -51,7 +41,6 @@ private object ResourceHelper {
                 loadString(it)
             }
         }.getOrDefault("")
-
     }
 
     fun loadString(inputStream: InputStream?): String {

--- a/sdk/src/test/java/com/uid2/sdk/data/UID2IdentityTest.kt
+++ b/sdk/src/test/java/com/uid2/sdk/data/UID2IdentityTest.kt
@@ -9,12 +9,28 @@ import org.junit.Test
 class UID2IdentityTest {
     @Test
     fun `test invalid json`() {
+        // Verify that completely invalid json is handled correctly.
         listOf(
             JSONObject(),
-            JSONObject(mapOf("key" to "value")),
-            JSONObject(TestData.INVALID_IDENTITY)
+            JSONObject(mapOf("key" to "value"))
         ).forEach {
             val identity = UID2Identity.fromJson(it)
+            assertNull(identity)
+        }
+
+        // Verify that if any of the mandatory parameters are missing, it's handled correctly.
+        listOf(
+            "advertising_token",
+            "refresh_token",
+            "identity_expires",
+            "refresh_expires",
+            "refresh_from",
+            "refresh_response_key"
+        ).forEach {
+            val json = JSONObject(TestData.VALID_IDENTITY)
+            json.remove(it)
+
+            val identity = UID2Identity.fromJson(json)
             assertNull(identity)
         }
     }


### PR DESCRIPTION
This PR includes the following:
 - Implementation of the `UID2Client` class. This is responsible for refreshing a token/identity. It makes the request, via the `NetworkSession` interface, decodes the output via the `DataEnvelope` and parses the response. After fleshing out this class, I decided to modify the `NetworkSession` to improve how it was utilised.
 - In a previous PR, I suggested porting a number of uses within `TestData` to be JSON based files, which i've done. I also took the advice on adding more tests around invalid responses, where I can programmatically take a valid response and tweak it (remove stuff) and verify the system behaved. This actually allowed me to find an issue with the code, where a "success" could be returned but without a valid UID2Identity.