### PR TITLE
Configure lint rules and baseline

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -17,6 +17,15 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+
+        abortOnError true
+        checkDependencies true
+        checkReleaseBuilds false
+        warningsAsErrors true
+    }
 }
 
 dependencies {

--- a/dev-app/lint-baseline.xml
+++ b/dev-app/lint-baseline.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.4.2" type="baseline" client="gradle" dependencies="true" name="AGP (7.4.2)" variant="all" version="7.4.2">
+
+    <issue
+        id="DataExtractionRules"
+        message="The attribute `android:allowBackup` is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute `android:dataExtractionRules` specifying an `@xml` resource which configures cloud backups and device transfers on Android 12 and higher."
+        errorLine1="        android:allowBackup=&quot;false&quot;"
+        errorLine2="                             ~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="8"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.mipmap.ic_launcher_round` appears to be unused">
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher_round.webp"/>
+    </issue>
+
+</issues>

--- a/sdk/lint-baseline.xml
+++ b/sdk/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.4.2" type="baseline" client="gradle" dependencies="true" name="AGP (7.4.2)" variant="all" version="7.4.2">
+
+</issues>


### PR DESCRIPTION
This PR enables lint configuration along with the current baseline of what's acceptable. Once this lands, we can look to enable lint checks as part of the PR process.