### PR TITLE
Implement automatic identity refreshing

### DIFF
--- a/sdk/src/main/java/com/uid2/sdk/utils/TimeUtils.kt
+++ b/sdk/src/main/java/com/uid2/sdk/utils/TimeUtils.kt
@@ -9,4 +9,9 @@ class TimeUtils {
      * Returns whether or not the given (epoch) time in milliseconds, is in the past.
      */
     fun hasExpired(expiryMs: Long) = expiryMs <= System.currentTimeMillis()
+
+    /**
+     * Returns the number of milliseconds difference between the given time and "now".
+     */
+    fun diffToNow(fromMs: Long) = fromMs - System.currentTimeMillis()
 }


### PR DESCRIPTION
This PR implements support for automatically refreshing the UID2Identity. After some consideration, I decided to go for a fairly basic approach:
 - When loading an identity from persistence, we will immediately check if it's suitable to be refreshed.
 - When an identity is set, or loaded from persistence, and is not yet ready to be refreshed, we will calculate the number of seconds until it can be. This will then be scheduled via the Dispatcher. If this scheduled time falls during when the consuming application is still running, then it will be refreshed. Otherwise, the Job will not execute and we will check (or schedule) again when the app is relaunched and the identity loaded from persistence.