### PR TITLE
Add support for version info

### DIFF
--- a/sdk/src/main/java/com/uid2/sdk/UID2.kt
+++ b/sdk/src/main/java/com/uid2/sdk/UID2.kt
@@ -1,0 +1,30 @@
+package com.uid2.sdk
+
+/**
+ * The structure representing a version of the SDK.
+ */
+data class Version(val major: Int, val minor: Int, val patch: Int)
+
+object UID2 {
+    private const val VERSION_STRING = "0.1.0"
+
+    private const val VERSION_COMPONENTS = 3
+    private val INVALID_VERSION = Version(0, 0, 0)
+
+    /**
+     * Gets the version of the included UID2 SDK library, in string format.
+     */
+    fun getVersion() = VERSION_STRING
+
+    /**
+     * Gets the version of the included UID2 SDK library, in its individual major, minor and patch components.
+     */
+    fun getVersionInfo(): Version {
+        val components = VERSION_STRING.split(".")
+        if (components.size != VERSION_COMPONENTS) {
+            return INVALID_VERSION
+        }
+
+        return Version(components[0].toInt(), components[0].toInt(), components[0].toInt())
+    }
+}

--- a/sdk/src/main/java/com/uid2/sdk/UID2Client.kt
+++ b/sdk/src/main/java/com/uid2/sdk/UID2Client.kt
@@ -34,6 +34,9 @@ class UID2Client(
         }.getOrNull()
     }
 
+    // We expect the Client to report a Version that is in the following format: Android-X.Y.Z
+    private val clientVersion: String by lazy { "Android-${UID2.getVersion()}" }
+
     @Throws(
         InvalidApiUrlException::class,
         RefreshTokenException::class,
@@ -52,7 +55,7 @@ class UID2Client(
         val request = NetworkRequest(
             NetworkRequestType.POST,
             mapOf(
-                "X-UID2-Client-Version" to "Android-0.1",
+                "X-UID2-Client-Version" to clientVersion,
                 "Content-Type" to "application/x-www-form-urlencoded"
             ),
             refreshToken

--- a/sdk/src/test/java/com/uid2/sdk/UID2Test.kt
+++ b/sdk/src/test/java/com/uid2/sdk/UID2Test.kt
@@ -1,0 +1,12 @@
+package com.uid2.sdk
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UID2Test {
+    @Test
+    fun `test version`() {
+        // Verify that the reported Version is in the expected format (x.y.z)
+        assertTrue(UID2.getVersion().matches(Regex("[0-9]+\\.[0-9]+\\.[0-9]+(-.+)?")))
+    }
+}


### PR DESCRIPTION
This PR includes the following:
 - A way to programmatically query the Version of the SDK (via `UID2.getVersion`)
 - A way to programmatically query the individual components of the Version of the SDK (via `UID2.getVersionInfo`)
 - An update to the `UID2Client` class to build the included `X-UID2-Client-Version` based upon this version
 - Additional Unit Test coverage