### PR TITLE
Migrate storage access over to IO dispatcher

### DIFF
--- a/sdk/src/main/java/com/uid2/UID2Manager.kt
+++ b/sdk/src/main/java/com/uid2/UID2Manager.kt
@@ -111,9 +111,11 @@ class UID2Manager internal constructor(
         }
 
     init {
-        // Attempt to load the Identity from storage. If successful, we can notify any observers.
-        storageManager.loadIdentity()?.let {
-            validateAndSetIdentity(it, null, false)
+        scope.launch {
+            // Attempt to load the Identity from storage. If successful, we can notify any observers.
+            storageManager.loadIdentity()?.let {
+                validateAndSetIdentity(it, null, false)
+            }
         }
     }
 
@@ -160,10 +162,12 @@ class UID2Manager internal constructor(
 
     private fun setIdentityInternal(identity: UID2Identity?, status: IdentityStatus, updateStorage: Boolean = true) {
         if (updateStorage) {
-            if (identity == null) {
-                storageManager.clear()
-            } else {
-                storageManager.saveIdentity(identity)
+            scope.launch {
+                if (identity == null) {
+                    storageManager.clear()
+                } else {
+                    storageManager.saveIdentity(identity)
+                }
             }
         }
 

--- a/sdk/src/main/java/com/uid2/storage/SharedPreferencesStorageManager.kt
+++ b/sdk/src/main/java/com/uid2/storage/SharedPreferencesStorageManager.kt
@@ -3,30 +3,40 @@ package com.uid2.storage
 import android.content.Context
 import android.content.SharedPreferences
 import com.uid2.data.UID2Identity
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
 /**
  * An implementation of the StorageManager that persists UID2Identity instances in clear-text via Shared Preferences.
  */
-class SharedPreferencesStorageManager(private val context: Context) : StorageManager {
+class SharedPreferencesStorageManager(
+    private val context: Context,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : StorageManager {
 
     private val preferences: SharedPreferences by lazy {
         context.getSharedPreferences(IDENTITY_KEY_FILE, Context.MODE_PRIVATE)
     }
 
-    override fun saveIdentity(identity: UID2Identity) =
+    override suspend fun saveIdentity(identity: UID2Identity) = withContext(ioDispatcher) {
         preferences.edit()
             .putString(IDENTITY_PREF_KEY, identity.toJson().toString(0))
             .commit()
-
-    override fun loadIdentity() = preferences.getString(IDENTITY_PREF_KEY, "")?.let {
-        runCatching { UID2Identity.fromJson(JSONObject(it)) }.getOrNull()
     }
 
-    override fun clear() =
+    override suspend fun loadIdentity() = withContext(ioDispatcher) {
+        preferences.getString(IDENTITY_PREF_KEY, "")?.let {
+            runCatching { UID2Identity.fromJson(JSONObject(it)) }.getOrNull()
+        }
+    }
+
+    override suspend fun clear() = withContext(ioDispatcher) {
         preferences.edit()
             .clear()
             .commit()
+    }
 
     private companion object {
         private const val IDENTITY_KEY_FILE = "uid2_identity"

--- a/sdk/src/main/java/com/uid2/storage/StorageManager.kt
+++ b/sdk/src/main/java/com/uid2/storage/StorageManager.kt
@@ -10,17 +10,17 @@ interface StorageManager {
     /**
      * Saves the given UID2Identity locally, allowing to be loaded later.
      */
-    fun saveIdentity(identity: UID2Identity): Boolean
+    suspend fun saveIdentity(identity: UID2Identity): Boolean
 
     /**
      * Loads any previously persisted UID2Identity locally. If no save data is found, this will just return null.
      */
-    fun loadIdentity(): UID2Identity?
+    suspend fun loadIdentity(): UID2Identity?
 
     /**
      * Clears any previously stored data.
      */
-    fun clear(): Boolean
+    suspend fun clear(): Boolean
 
     companion object {
         private var instance: StorageManager? = null

--- a/sdk/src/test/java/com/uid2/UID2ManagerTest.kt
+++ b/sdk/src/test/java/com/uid2/UID2ManagerTest.kt
@@ -12,6 +12,7 @@ import com.uid2.utils.TimeUtils
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -20,14 +21,17 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -56,9 +60,7 @@ class UID2ManagerTest {
         whenever(timeUtils.hasExpired(anyLong())).thenReturn(false)
 
         whenever(storageManager.loadIdentity()).thenReturn(initialIdentity)
-        manager = UID2Manager(client, storageManager, timeUtils, testDispatcher, false).apply {
-            onIdentityChangedListener = listener
-        }
+        manager = withManager(client, storageManager, timeUtils, testDispatcher, false, listener)
     }
 
     @Test
@@ -79,6 +81,7 @@ class UID2ManagerTest {
 
         // Verify that setting the Identity on the Manager, results in it being persisted via the StorageManager.
         manager.setIdentity(identity)
+        testDispatcher.scheduler.advanceUntilIdle()
         verify(storageManager).saveIdentity(identity)
 
         // Verify that the Manager updated with the new identity and reported the state changes appropriately.
@@ -94,6 +97,7 @@ class UID2ManagerTest {
 
         // Reset the Manager's identity
         manager.resetIdentity()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         // Verify that the Manager updated with the reset identity and reported the state changes appropriately.
         assertManagerState(manager, null, NO_IDENTITY)
@@ -101,7 +105,7 @@ class UID2ManagerTest {
 
     @Test
     fun `refresh no-op when no identity`() {
-        val manager = UID2Manager(client, mock(), timeUtils, testDispatcher, false)
+        val manager = withManager(client, mock(), timeUtils, testDispatcher, false, null)
         assertNull(manager.currentIdentity)
 
         // Verify that if we attempt to refresh the Identity when one is not set, nothing happens.
@@ -173,15 +177,18 @@ class UID2ManagerTest {
             }
         }
 
+        // Start with a clean state.
+        clearInvocations(listener)
+
         // Ask the manager to refresh, allowing the current TestDispatcher to process any jobs.
         manager.refreshIdentity()
-        testDispatcher.scheduler.runCurrent()
+        testDispatcher.scheduler.advanceTimeBy(TimeUnit.SECONDS.toMillis(1))
 
         // Verify that nothing changed after the identity failed to refresh.
         verifyNoInteractions(listener)
 
         // Advance the timer enough so that the Manager should have had an opportunity to retry refreshing the identity.
-        testScheduler.advanceTimeBy(TimeUnit.SECONDS.toMillis(6))
+        testDispatcher.scheduler.advanceTimeBy(TimeUnit.SECONDS.toMillis(6))
         assertManagerState(manager, newIdentity, REFRESHED)
     }
 
@@ -193,8 +200,10 @@ class UID2ManagerTest {
         // Configure a Refresh to be required in +5 seconds when asked. This should result in the Manager scheduling
         // that via the TestDispatcher.
         val newIdentity = withRandomIdentity()
+        var refreshed = false
         whenever(timeUtils.diffToNow(anyLong())).thenReturn(TimeUnit.SECONDS.toMillis(5))
         whenever(client.refreshIdentity(anyString(), anyString())).thenAnswer {
+            refreshed = true
             RefreshPackage(
                 newIdentity,
                 REFRESHED,
@@ -203,17 +212,18 @@ class UID2ManagerTest {
         }
 
         // Build the Manager.
-        val manager = UID2Manager(client, storageManager, timeUtils, testDispatcher, true)
+        val manager = withManager(client, storageManager, timeUtils, testDispatcher, true, listener)
         assertNull(manager.currentIdentity)
 
-        // Set the initial identity along with the Listener. We do this afterwards as we don't care about that initial
-        // notification.
+        // Set the initial identity. We will allow this to be processed before we clear the state of the listener.
         manager.setIdentity(initialIdentity)
-        manager.onIdentityChangedListener = listener
+        testScheduler.advanceTimeBy(10)
+        clearInvocations(listener)
 
         // Allow the Test Scheduler to advance by a second, and verify that no refresh has yet occurred.
         testScheduler.advanceTimeBy(TimeUnit.SECONDS.toMillis(1))
         verifyNoInteractions(listener)
+        assertFalse(refreshed)
 
         // Now advance the Test Scheduler past the time we expect a refresh to occur.
         testScheduler.advanceTimeBy(TimeUnit.SECONDS.toMillis(5))
@@ -222,6 +232,7 @@ class UID2ManagerTest {
         // automatic refreshing *before* to avoid a loop where this new identity will refresh every 5 seconds, resulting
         // in a never-ending test!
         manager.automaticRefreshEnabled = false
+        assertTrue(refreshed)
         assertManagerState(manager, newIdentity, REFRESHED)
     }
 
@@ -250,6 +261,23 @@ class UID2ManagerTest {
         assertEquals(expectedStates, states)
 
         job.cancel()
+    }
+
+    private fun withManager(
+        client: UID2Client,
+        storageManager: StorageManager,
+        timeUtils: TimeUtils,
+        dispatcher: CoroutineDispatcher,
+        initialAutomaticRefreshEnabled: Boolean,
+        listener: UID2ManagerIdentityChangedListener?
+    ): UID2Manager {
+        return UID2Manager(client, storageManager, timeUtils, dispatcher, initialAutomaticRefreshEnabled).apply {
+            onIdentityChangedListener = listener
+
+            if (!initialAutomaticRefreshEnabled) {
+                testDispatcher.scheduler.advanceUntilIdle()
+            }
+        }
     }
 
     /**

--- a/sdk/src/test/java/com/uid2/storage/SharedPreferencesStorageManagerTest.kt
+++ b/sdk/src/test/java/com/uid2/storage/SharedPreferencesStorageManagerTest.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.SharedPreferences.Editor
 import com.uid2.data.UID2Identity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -16,8 +20,11 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class SharedPreferencesStorageManagerTest {
+    private lateinit var testDispatcher: TestDispatcher
+
     private val context: Context = mock()
     private val preferences: SharedPreferences = mock()
     private val editor: Editor = mock()
@@ -26,6 +33,8 @@ class SharedPreferencesStorageManagerTest {
 
     @Before
     fun before() {
+        testDispatcher = StandardTestDispatcher()
+
         whenever(context.getSharedPreferences(any(), any())).thenReturn(preferences)
         whenever(preferences.edit()).thenReturn(editor)
 
@@ -49,7 +58,7 @@ class SharedPreferencesStorageManagerTest {
     }
 
     @Test
-    fun `test storage stores and loads identity`() {
+    fun `test storage stores and loads identity`() = runTest(testDispatcher) {
         val identity = UID2Identity(
             "ad token",
             "refresh token",
@@ -67,7 +76,7 @@ class SharedPreferencesStorageManagerTest {
     }
 
     @Test
-    fun `test clears identity`() {
+    fun `test clears identity`() = runTest(testDispatcher) {
         val identity = UID2Identity(
             "ad token",
             "refresh token",


### PR DESCRIPTION
Access to the identity storage can (and should) be done via an IO dispatcher. We are already async when loading/saving the identity, so makes sense to ensure that this work is being done on an appropriate thread.