### PR TITLE
Implement initial support for SDK deployment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,3 +10,7 @@ plugins {
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
     id 'org.jetbrains.dokka' version '1.8.10' apply false
 }
+
+allprojects {
+    version = '0.1.0-SNAPSHOT'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,10 @@ plugins {
     id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
     id 'org.jetbrains.dokka' version '1.8.10' apply false
+    id 'com.vanniktech.maven.publish' version "0.25.1" apply false
 }
 
 allprojects {
+    group = 'com.uid'
     version = '0.1.0-SNAPSHOT'
 }

--- a/common.gradle
+++ b/common.gradle
@@ -13,6 +13,12 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    buildTypes {
+        all {
+            buildConfigField "String", "VERSION", "\"$project.version\""
+        }
+    }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,47 @@
+Releasing
+=========
+
+Cutting a Release
+-----------------
+
+1. Update `CHANGELOG.md`.
+
+2. Set versions:
+
+    ```
+    export RELEASE_VERSION=X.Y.Z
+    export NEXT_VERSION=X.Y.Z-SNAPSHOT
+    ```
+
+3. Update versions:
+
+    ```
+    sed -i "" \
+      "s/version = \".*\"/version = \"$RELEASE_VERSION\"/g" \
+      build.gradle
+    ```
+
+4. Tag the release and push to GitHub.
+
+    ```
+    git commit -am "Prepare for release $RELEASE_VERSION."
+    git tag -a r$RELEASE_VERSION -m "Version $RELEASE_VERSION"
+    git push && git push --tags
+    ```
+
+5. Wait for [GitHub Actions][github_actions] to start the publish job.
+
+6. Prepare for ongoing development and push to GitHub.
+
+    ```
+    sed -i "" \
+      "s/version = \".*\"/version = \"$NEXT_VERSION\"/g" \
+      build.gradle
+    git commit -am "Prepare next development version."
+    git push
+    ```
+
+7. Confirm the [GitHub Actions][github_actions] publish job succeeded.
+
+[github_actions]: https://github.com/IABTechLab/uid2-android-sdk/actions
+[sonatype_issues]: https://issues.sonatype.org/

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,7 +1,10 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.dokka'
+    id 'com.vanniktech.maven.publish'
 }
 
 apply from:  rootProject.file("$rootDir/common.gradle")
@@ -61,4 +64,39 @@ tasks.register('dokkaJavadocJar', Jar.class) {
     dependsOn(dokkaJavadoc)
     from(dokkaJavadoc)
     archiveClassifier.set("javadoc")
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Maven Publishing
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.S01)
+    signAllPublications()
+
+    coordinates(project.group, "uid2-android-sdk", project.version)
+
+    pom {
+        name = project.name
+        description = 'A framework for integration UID2 into Android applications.'
+        url = 'https://github.com/IABTechLab/uid2-android-sdk'
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = 'IABTechLab'
+                name = 'IAB Tech Lab'
+                url = 'https://iabtechlab.com/'
+            }
+        }
+        scm {
+            url = 'https://github.com/IABTechLab/uid2-android-sdk'
+            connection = 'scm:git:git@github.com:IABTechLab/uid2-android-sdk.git'
+            developerConnection = 'scm:git:ssh://git@github.com:IABTechLab/uid2-android-sdk.git'
+        }
+    }
 }

--- a/sdk/src/main/java/com/uid2/UID2.kt
+++ b/sdk/src/main/java/com/uid2/UID2.kt
@@ -6,7 +6,7 @@ package com.uid2
 data class Version(val major: Int, val minor: Int, val patch: Int)
 
 object UID2 {
-    private const val VERSION_STRING = "0.1.0"
+    private const val VERSION_STRING = BuildConfig.VERSION
 
     private const val VERSION_COMPONENTS = 3
     private val INVALID_VERSION = Version(0, 0, 0)

--- a/securesignals-gma/src/main/java/com/uid2/securesignals/gma/UID2SecureSignals.kt
+++ b/securesignals-gma/src/main/java/com/uid2/securesignals/gma/UID2SecureSignals.kt
@@ -1,9 +1,10 @@
 package com.uid2.securesignals.gma
 
+import com.uid2.BuildConfig
 import com.uid2.Version
 
 object UID2SecureSignals {
-    private const val VERSION_STRING = "0.1.0"
+    private const val VERSION_STRING = BuildConfig.VERSION
 
     private const val VERSION_COMPONENTS = 3
     private val INVALID_VERSION = Version(0, 0, 0)

--- a/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignals.kt
+++ b/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignals.kt
@@ -1,9 +1,10 @@
 package com.uid2.securesignals.ima
 
+import com.uid2.BuildConfig
 import com.uid2.Version
 
 object UID2SecureSignals {
-    private const val VERSION_STRING = "0.1.0"
+    private const val VERSION_STRING = BuildConfig.VERSION
 
     private const val VERSION_COMPONENTS = 3
     private val INVALID_VERSION = Version(0, 0, 0)


### PR DESCRIPTION
This PR includes the following:
 - Modified versioning to all pull from `build.gradle`
 - Modified versioning to allow `-SNAPSHOT` versions
 - Integrated plugin for deployment to Maven Central and configured
 - Added releasing document to demonstrate how we will release.