### PR TITLE
Improve api visibility

### DIFF
--- a/dev-app/src/main/java/com/uid2/dev/network/AppUID2Client.kt
+++ b/dev-app/src/main/java/com/uid2/dev/network/AppUID2Client.kt
@@ -1,9 +1,12 @@
 package com.uid2.dev.network
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
 import android.util.Base64
 import com.uid2.data.UID2Identity
-import com.uid2.extensions.getMetadata
 import com.uid2.network.DataEnvelope
 import java.io.ByteArrayOutputStream
 import java.net.URI
@@ -191,5 +194,17 @@ class AppUID2Client(
                 it.getString(UID2_API_SECRET_KEY, "")
             )
         }
+
+        private fun Context.getMetadata(): Bundle = packageManager.getApplicationInfoCompat(
+            packageName,
+            PackageManager.GET_META_DATA
+        ).metaData
+
+        private fun PackageManager.getApplicationInfoCompat(packageName: String, flags: Int = 0): ApplicationInfo =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(flags.toLong()))
+            } else {
+                @Suppress("DEPRECATION") getApplicationInfo(packageName, flags)
+            }
     }
 }

--- a/sdk/src/main/java/com/uid2/UID2.kt
+++ b/sdk/src/main/java/com/uid2/UID2.kt
@@ -5,6 +5,9 @@ package com.uid2
  */
 data class Version(val major: Int, val minor: Int, val patch: Int)
 
+/**
+ * An object exposing the version information associated with the UID2 SDK.
+ */
 object UID2 {
     private const val VERSION_STRING = BuildConfig.VERSION
 
@@ -14,7 +17,7 @@ object UID2 {
     /**
      * Gets the version of the included UID2 SDK library, in string format.
      */
-    fun getVersion() = VERSION_STRING
+    fun getVersion(): String = VERSION_STRING
 
     /**
      * Gets the version of the included UID2 SDK library, in its individual major, minor and patch components.

--- a/sdk/src/main/java/com/uid2/UID2Client.kt
+++ b/sdk/src/main/java/com/uid2/UID2Client.kt
@@ -18,7 +18,7 @@ import org.json.JSONObject
  * This class is responsible for refreshing the identity, using a provided refresh token. The payload response will be
  * encrypted, so also is provided a key to allow decryption.
  */
-class UID2Client(
+internal class UID2Client(
     private val apiUrl: String,
     private val session: NetworkSession,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/sdk/src/main/java/com/uid2/UID2Exception.kt
+++ b/sdk/src/main/java/com/uid2/UID2Exception.kt
@@ -3,29 +3,29 @@ package com.uid2
 /**
  * Base class for all custom exceptions reported by the UID2 SDK.
  */
-open class UID2Exception(message: String? = null, cause: Throwable? = null): Exception(message, cause)
+internal open class UID2Exception(message: String? = null, cause: Throwable? = null): Exception(message, cause)
 
 /**
  * The SDK has been initialized *after* it's been created.
  */
-class InitializationException(message: String? = null): UID2Exception(message)
+internal class InitializationException(message: String? = null): UID2Exception(message)
 
 /**
  * The configured API URL is invalid.
  */
-class InvalidApiUrlException: UID2Exception()
+internal class InvalidApiUrlException: UID2Exception()
 
 /**
  * The attempt to refresh the token/identity via the API failed.
  */
-class RefreshTokenException(val statusCode: Int): UID2Exception()
+internal class RefreshTokenException(val statusCode: Int): UID2Exception()
 
 /**
  * The encrypted payload could not be decrypted successfully.
  */
-class PayloadDecryptException: UID2Exception()
+internal class PayloadDecryptException: UID2Exception()
 
 /**
  * The decrypted payload appears invalid.
  */
-class InvalidPayloadException: UID2Exception()
+internal class InvalidPayloadException: UID2Exception()

--- a/sdk/src/main/java/com/uid2/data/IdentityPackage.kt
+++ b/sdk/src/main/java/com/uid2/data/IdentityPackage.kt
@@ -4,7 +4,7 @@ package com.uid2.data
  * The lifecycle of the Identity will cause the UID2Identity to change, along with potentially becoming invalid in some
  * circumstances. This class represents combines the different possible states.
  */
-data class IdentityPackage(
+internal data class IdentityPackage(
     val valid: Boolean,
     val errorMessage: String?,
     val identity: UID2Identity?,

--- a/sdk/src/main/java/com/uid2/extensions/ContextEx.kt
+++ b/sdk/src/main/java/com/uid2/extensions/ContextEx.kt
@@ -9,7 +9,7 @@ import android.os.Bundle
 /**
  * Helper method to extract the MetaData Bundle associated with the given Context.
  */
-fun Context.getMetadata(): Bundle = packageManager.getApplicationInfoCompat(
+internal fun Context.getMetadata(): Bundle = packageManager.getApplicationInfoCompat(
     packageName,
     PackageManager.GET_META_DATA
 ).metaData

--- a/sdk/src/main/java/com/uid2/extensions/StringEx.kt
+++ b/sdk/src/main/java/com/uid2/extensions/StringEx.kt
@@ -6,13 +6,13 @@ import org.json.JSONObject
 /**
  * Extension method to decode a String base Base64.
  */
-fun String.decodeBase64(): ByteArray? = runCatching { Base64.decode(this, Base64.DEFAULT) }.getOrNull()
+internal fun String.decodeBase64(): ByteArray? = runCatching { Base64.decode(this, Base64.DEFAULT) }.getOrNull()
 
 /**
  * Extension to parse a given String as JSON and convert to a Map. If parsing fails, e.g. the JSON
  * is not well formed, then null will be returned.
  */
-fun String.decodeJsonToMap(): Map<String, Any>? {
+internal fun String.decodeJsonToMap(): Map<String, Any>? {
     val json = runCatching { JSONObject(this) }.getOrNull() ?: return null
 
     return json.keys().asSequence().map {

--- a/sdk/src/main/java/com/uid2/network/DataEnvelope.kt
+++ b/sdk/src/main/java/com/uid2/network/DataEnvelope.kt
@@ -9,7 +9,8 @@ import javax.crypto.spec.SecretKeySpec
  * This object is responsible for decoding encrypted responses when refreshing the Identity. The type of encryption used
  * as well as the format of the expected data can be found in the following documentation:
  *
- * https://github.com/IABTechLab/uid2docs/blob/main/api/v2/ref-info/encryption-decryption.md
+ * **See Also:**
+ * [GitHub](https://github.com/IABTechLab/uid2docs/blob/main/api/v2/getting-started/gs-encryption-decryption.md)
  */
 object DataEnvelope {
     // The name and transformation of the encryption algorithm used.
@@ -32,6 +33,10 @@ object DataEnvelope {
      *
      * This relies on the format of the data matching that spec-ed in the API documentation. We assume that it's AES
      * encrypted, and includes the IV in the first 12 bytes of the buffer.
+     * 
+     * @param key The key, in Base64 format, required to decode the given data.
+     * @param data The data, in Base64 format, that needs to be decoded.
+     * @return The unencrypted data. If this decryption fails, null is returned.
      */
     fun decrypt(key: String, data: String, isRefresh: Boolean): ByteArray? {
         // Attempt to decrypt the given data with the provided key. Both the key and data are expected to be in Base64

--- a/sdk/src/main/java/com/uid2/network/DefaultNetworkSession.kt
+++ b/sdk/src/main/java/com/uid2/network/DefaultNetworkSession.kt
@@ -4,11 +4,17 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 /**
- * A default implementation of NetworkSession that leverages HttpUrlConnection to make the necessary
+ * A default implementation of [NetworkSession] that leverages [HttpURLConnection] to make the necessary
  * GET and POST requests.
+ *
+ * If a consuming application wants to take control over the network requests, they can implement their own custom
+ * [NetworkSession] and provide it when initialising the SDK via [com.uid2.UID2Manager.init]
  */
 open class DefaultNetworkSession : NetworkSession {
 
+    /**
+     * Loads the given [URL] and [NetworkRequest] using [HttpURLConnection].
+     */
     override fun loadData(url: URL, request: NetworkRequest): NetworkResponse {
         val connection = openConnection(url).apply {
             requestMethod = request.type.toRequestMethod()

--- a/sdk/src/main/java/com/uid2/network/NetworkSession.kt
+++ b/sdk/src/main/java/com/uid2/network/NetworkSession.kt
@@ -6,13 +6,25 @@ import java.net.URL
  * The type of request that needs to be made. We currently only require either a GET or a POST.
  */
 enum class NetworkRequestType {
+
+    /**
+     * A HTTP GET request.
+     */
     GET,
+
+    /**
+     * A HTTP POST request (which should then include data within the body).
+     */
     POST
 }
 
 /**
  * A class which represents a network request. This could include a number of headers to be used within the request,
  * along with if the request is a POST, some additional data which needs to be written to the connection.
+ *
+ * @param type The type of request required.
+ * @param headers The collection of headers to be used in the request (in key/value pairs).
+ * @param data The optional body data, used in a [NetworkRequestType.POST].
  */
 data class NetworkRequest(
     val type: NetworkRequestType,
@@ -22,6 +34,9 @@ data class NetworkRequest(
 
 /**
  * A class which represents a network response. This will include the HTTP status code, as well as any response data.
+ *
+ * @param code The HTTP response code received after attempting to make the request.
+ * @param data The body data contained within the response. If none is available, the empty string should be provided.
  */
 data class NetworkResponse(
     val code: Int,
@@ -36,6 +51,10 @@ interface NetworkSession {
 
     /**
      * Requests the given URL with the details provided in the request.
+     *
+     * @param url The [URL] endpoint associated with the request.
+     * @param request The details of the required request.
+     * @return The [NetworkResponse] which contains the outcome of the attempted request.
      */
     fun loadData(url: URL, request: NetworkRequest): NetworkResponse
 }

--- a/sdk/src/main/java/com/uid2/network/RefreshPackage.kt
+++ b/sdk/src/main/java/com/uid2/network/RefreshPackage.kt
@@ -6,7 +6,7 @@ import com.uid2.data.UID2Identity
 /**
  * The data available after attempting to refresh the Identity.
  */
-data class RefreshPackage(
+internal data class RefreshPackage(
     val identity: UID2Identity?,
     val status: IdentityStatus,
     val message: String

--- a/sdk/src/main/java/com/uid2/network/RefreshResponse.kt
+++ b/sdk/src/main/java/com/uid2/network/RefreshResponse.kt
@@ -14,7 +14,7 @@ import org.json.JSONObject
  *
  * https://github.com/IABTechLab/uid2docs/blob/main/api/v2/endpoints/post-token-refresh.md#decrypted-json-response-format
  */
-data class RefreshResponse(
+internal data class RefreshResponse(
     val body: UID2Identity?,
     val status: Status,
     val message: String?

--- a/sdk/src/main/java/com/uid2/storage/SharedPreferencesStorageManager.kt
+++ b/sdk/src/main/java/com/uid2/storage/SharedPreferencesStorageManager.kt
@@ -11,7 +11,7 @@ import org.json.JSONObject
 /**
  * An implementation of the StorageManager that persists UID2Identity instances in clear-text via Shared Preferences.
  */
-class SharedPreferencesStorageManager(
+internal class SharedPreferencesStorageManager(
     private val context: Context,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : StorageManager {

--- a/sdk/src/main/java/com/uid2/storage/StorageManager.kt
+++ b/sdk/src/main/java/com/uid2/storage/StorageManager.kt
@@ -6,7 +6,7 @@ import com.uid2.data.UID2Identity
 /**
  * An interface controlling access to local storage, used for the persistence of UID2Identity instances.
  */
-interface StorageManager {
+internal interface StorageManager {
     /**
      * Saves the given UID2Identity locally, allowing to be loaded later.
      */

--- a/sdk/src/main/java/com/uid2/utils/TimeUtils.kt
+++ b/sdk/src/main/java/com/uid2/utils/TimeUtils.kt
@@ -3,7 +3,7 @@ package com.uid2.utils
 /**
  * A class containing utility methods around the current time.
  */
-class TimeUtils {
+internal class TimeUtils {
 
     /**
      * Returns whether or not the given (epoch) time in milliseconds, is in the past.

--- a/securesignals-gma/src/main/java/com/uid2/securesignals/gma/UID2SecureSignals.kt
+++ b/securesignals-gma/src/main/java/com/uid2/securesignals/gma/UID2SecureSignals.kt
@@ -3,6 +3,9 @@ package com.uid2.securesignals.gma
 import com.uid2.BuildConfig
 import com.uid2.Version
 
+/**
+ * An object exposing the version information associated with the UID2 GMA Plugin.
+ */
 object UID2SecureSignals {
     private const val VERSION_STRING = BuildConfig.VERSION
 

--- a/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignals.kt
+++ b/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignals.kt
@@ -3,6 +3,9 @@ package com.uid2.securesignals.ima
 import com.uid2.BuildConfig
 import com.uid2.Version
 
+/**
+ * An object exposing the version information associated with the UID2 IMA Plugin.
+ */
 object UID2SecureSignals {
     private const val VERSION_STRING = BuildConfig.VERSION
 

--- a/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignalsAdapter.kt
+++ b/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignalsAdapter.kt
@@ -6,9 +6,12 @@ import com.google.ads.interactivemedia.v3.api.signals.SecureSignalsAdapter
 import com.google.ads.interactivemedia.v3.api.signals.SecureSignalsCollectSignalsCallback
 import com.google.ads.interactivemedia.v3.api.signals.SecureSignalsInitializeCallback
 import com.uid2.UID2
-import com.uid2.InitializationException
-import com.uid2.UID2Exception
 import com.uid2.UID2Manager
+
+/**
+ * A custom exception type that is used to report failures from the UID2SecureSignalsAdapter when an error has occurred.
+ */
+class UID2SecureSignalsException(message: String? = null, cause: Throwable? = null): Exception(message, cause)
 
 /**
  * An implementation of Google's IMA SecureSignalsAdapter that integrates UID2 tokens, accessed via the UID2Manager.
@@ -39,7 +42,7 @@ class UID2SecureSignalsAdapter: SecureSignalsAdapter {
         } else if (UID2Manager.isInitialized()) {
             callback?.onSuccess()
         } else {
-            callback?.onFailure(InitializationException("No Context provided to initialise UID2Manager"))
+            callback?.onFailure(UID2SecureSignalsException("No Context provided to initialise UID2Manager"))
         }
     }
 
@@ -51,7 +54,7 @@ class UID2SecureSignalsAdapter: SecureSignalsAdapter {
         if (token != null) {
             callback?.onSuccess(token)
         } else {
-            callback?.onFailure(UID2Exception("No Advertising Token available"))
+            callback?.onFailure(UID2SecureSignalsException("No Advertising Token available"))
         }
     }
 }


### PR DESCRIPTION
After reviewing the generated KDocs from the SDK, I identified a number of improvements:
 - Switching to `internal` for code that shouldn't be exposed outside the SDK. Consumers shouldn't be utilising these types and ideally we limit our public API.
 - Improve documentation, e.g. add when missing and enable links between types.