### PR TITLE
Implement workflow to publish to Maven

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish Main
+
+on:
+  push:
+    branches:
+      - main
+
+  # This allows us to manually run this job
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    if: github.repository == 'IABTechLab/uid2-android-sdk' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Upload Artifacts
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: clean publish --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_REPO_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_REPO_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -70,7 +70,7 @@ tasks.register('dokkaJavadocJar', Jar.class) {
 // Maven Publishing
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.S01)
+    publishToMavenCentral(SonatypeHost.S01, true)
     signAllPublications()
 
     coordinates(project.group, "uid2-android-sdk", project.version)


### PR DESCRIPTION
This PR adds a new GitHub workflow that will build and publish `master` to MavenCentral.