### PR TITLE
Add support to persist identity status

### DIFF
--- a/sdk/src/main/java/com/uid2/UID2Manager.kt
+++ b/sdk/src/main/java/com/uid2/UID2Manager.kt
@@ -113,8 +113,8 @@ class UID2Manager internal constructor(
     init {
         scope.launch {
             // Attempt to load the Identity from storage. If successful, we can notify any observers.
-            storageManager.loadIdentity()?.let {
-                validateAndSetIdentity(it, null, false)
+            storageManager.loadIdentity().let {
+                validateAndSetIdentity(it.first, it.second, false)
             }
         }
     }
@@ -166,7 +166,7 @@ class UID2Manager internal constructor(
                 if (identity == null) {
                     storageManager.clear()
                 } else {
-                    storageManager.saveIdentity(identity)
+                    storageManager.saveIdentity(identity, status)
                 }
             }
         }

--- a/sdk/src/main/java/com/uid2/data/IdentityStatus.kt
+++ b/sdk/src/main/java/com/uid2/data/IdentityStatus.kt
@@ -6,7 +6,7 @@ package com.uid2.data
  * This has been translated from the Web implement, see the following for more information:
  * https://github.com/IABTechLab/uid2-web-integrations/blob/5a8295c47697cdb1fe36997bc2eb2e39ae143f8b/src/Uid2InitCallbacks.ts#L12-L20
  */
-enum class IdentityStatus(private val value: Int) {
+enum class IdentityStatus(val value: Int) {
     ESTABLISHED(0),
     REFRESHED(1),
     EXPIRED(100),

--- a/sdk/src/main/java/com/uid2/storage/SharedPreferencesStorageManager.kt
+++ b/sdk/src/main/java/com/uid2/storage/SharedPreferencesStorageManager.kt
@@ -2,6 +2,8 @@ package com.uid2.storage
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.uid2.data.IdentityStatus
+import com.uid2.data.IdentityStatus.NO_IDENTITY
 import com.uid2.data.UID2Identity
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -20,16 +22,22 @@ class SharedPreferencesStorageManager(
         context.getSharedPreferences(IDENTITY_KEY_FILE, Context.MODE_PRIVATE)
     }
 
-    override suspend fun saveIdentity(identity: UID2Identity) = withContext(ioDispatcher) {
+    override suspend fun saveIdentity(identity: UID2Identity, status: IdentityStatus) = withContext(ioDispatcher) {
         preferences.edit()
             .putString(IDENTITY_PREF_KEY, identity.toJson().toString(0))
+            .putInt(IDENTITY_STATUS_PREF_KEY, status.value)
             .commit()
     }
 
     override suspend fun loadIdentity() = withContext(ioDispatcher) {
-        preferences.getString(IDENTITY_PREF_KEY, "")?.let {
+        val identity = preferences.getString(IDENTITY_PREF_KEY, "")?.let {
             runCatching { UID2Identity.fromJson(JSONObject(it)) }.getOrNull()
         }
+        val status = preferences.getInt(IDENTITY_STATUS_PREF_KEY, NO_IDENTITY.value).let {
+            runCatching { IdentityStatus.fromValue(it) }.getOrDefault(NO_IDENTITY)
+        }
+
+        return@withContext Pair(identity, status)
     }
 
     override suspend fun clear() = withContext(ioDispatcher) {
@@ -41,5 +49,6 @@ class SharedPreferencesStorageManager(
     private companion object {
         private const val IDENTITY_KEY_FILE = "uid2_identity"
         private const val IDENTITY_PREF_KEY = "identity"
+        private const val IDENTITY_STATUS_PREF_KEY = "status"
     }
 }

--- a/sdk/src/main/java/com/uid2/storage/StorageManager.kt
+++ b/sdk/src/main/java/com/uid2/storage/StorageManager.kt
@@ -1,6 +1,7 @@
 package com.uid2.storage
 
 import android.content.Context
+import com.uid2.data.IdentityStatus
 import com.uid2.data.UID2Identity
 
 /**
@@ -8,14 +9,14 @@ import com.uid2.data.UID2Identity
  */
 interface StorageManager {
     /**
-     * Saves the given UID2Identity locally, allowing to be loaded later.
+     * Saves the given UID2Identity and status locally, allowing to be loaded later.
      */
-    suspend fun saveIdentity(identity: UID2Identity): Boolean
+    suspend fun saveIdentity(identity: UID2Identity, status: IdentityStatus): Boolean
 
     /**
-     * Loads any previously persisted UID2Identity locally. If no save data is found, this will just return null.
+     * Loads any previously persisted UID2Identity and status locally.
      */
-    suspend fun loadIdentity(): UID2Identity?
+    suspend fun loadIdentity(): Pair<UID2Identity?, IdentityStatus>
 
     /**
      * Clears any previously stored data.

--- a/sdk/src/test/java/com/uid2/UID2ManagerTest.kt
+++ b/sdk/src/test/java/com/uid2/UID2ManagerTest.kt
@@ -50,6 +50,7 @@ class UID2ManagerTest {
 
     private lateinit var manager: UID2Manager
     private val initialIdentity = withRandomIdentity()
+    private val initialStatus = ESTABLISHED
     private val listener: UID2ManagerIdentityChangedListener = mock()
 
     @Before
@@ -59,7 +60,7 @@ class UID2ManagerTest {
         // By default, we won't expire tokens.
         whenever(timeUtils.hasExpired(anyLong())).thenReturn(false)
 
-        whenever(storageManager.loadIdentity()).thenReturn(initialIdentity)
+        whenever(storageManager.loadIdentity()).thenReturn(Pair(initialIdentity, initialStatus))
         manager = withManager(client, storageManager, timeUtils, testDispatcher, false, listener)
     }
 
@@ -68,7 +69,7 @@ class UID2ManagerTest {
         // Verify that the initial state of the manager reflects the restored Identity.
         assertNotNull(manager.currentIdentity)
         assertEquals(initialIdentity, manager.currentIdentity)
-        assertEquals(ESTABLISHED, manager.currentIdentityStatus)
+        assertEquals(initialStatus, manager.currentIdentityStatus)
     }
 
     @Test
@@ -82,7 +83,7 @@ class UID2ManagerTest {
         // Verify that setting the Identity on the Manager, results in it being persisted via the StorageManager.
         manager.setIdentity(identity)
         testDispatcher.scheduler.advanceUntilIdle()
-        verify(storageManager).saveIdentity(identity)
+        verify(storageManager).saveIdentity(identity, ESTABLISHED)
 
         // Verify that the Manager updated with the new identity and reported the state changes appropriately.
         assertManagerState(manager, identity, ESTABLISHED)

--- a/sdk/src/test/java/com/uid2/storage/SharedPreferencesStorageManagerTest.kt
+++ b/sdk/src/test/java/com/uid2/storage/SharedPreferencesStorageManagerTest.kt
@@ -3,13 +3,15 @@ package com.uid2.storage
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.SharedPreferences.Editor
+import com.uid2.data.IdentityStatus.ESTABLISHED
+import com.uid2.data.IdentityStatus.NO_IDENTITY
 import com.uid2.data.UID2Identity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,6 +21,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.stubbing.Answer
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -40,15 +43,24 @@ class SharedPreferencesStorageManagerTest {
 
         // Configure the Editor so that any values persisted are actually stored in a local cache.
         // This can then be used later when reading back these same values.
-        whenever(editor.putString(any(), any())).thenAnswer {
+        val editorPutAnswer = Answer {
             editorCache[it.arguments[0].toString()] = it.arguments[1]
-            return@thenAnswer editor
+            return@Answer editor
         }
+        whenever(editor.putString(any(), any())).thenAnswer(editorPutAnswer)
+        whenever(editor.putInt(any(), any())).thenAnswer(editorPutAnswer)
 
         // Configure the getX methods to return the cached value.
-        whenever(preferences.getString(any(), anyOrNull())).thenAnswer {
-            return@thenAnswer editorCache[it.arguments[0].toString()]
+        val editorGetAnswer = Answer {
+            val key = it.arguments[0].toString()
+            if (!editorCache.containsKey(key)) {
+                return@Answer it.arguments[1]
+            }
+
+            return@Answer editorCache[key]
         }
+        whenever(preferences.getString(any(), anyOrNull())).thenAnswer(editorGetAnswer)
+        whenever(preferences.getInt(any(), any())).thenAnswer(editorGetAnswer)
 
         // Configure the Editor so that any requests to clear will actually clear the backed editor cache.
         whenever(editor.clear()).thenAnswer {
@@ -69,10 +81,11 @@ class SharedPreferencesStorageManagerTest {
         )
 
         val storageManager = SharedPreferencesStorageManager(context)
-        storageManager.saveIdentity(identity)
+        storageManager.saveIdentity(identity, ESTABLISHED)
 
         val loaded = storageManager.loadIdentity()
-        assertEquals(identity, loaded)
+        assertEquals(identity, loaded.first)
+        assertEquals(ESTABLISHED, loaded.second)
     }
 
     @Test
@@ -87,14 +100,15 @@ class SharedPreferencesStorageManagerTest {
         )
 
         val storageManager = SharedPreferencesStorageManager(context)
-        storageManager.saveIdentity(identity)
+        storageManager.saveIdentity(identity, ESTABLISHED)
 
         // After saving the identity to the StorageManager, clear them.
         storageManager.clear()
 
         // Verify that we're no longer able to load the old identity, and that the Shared Preferences have been cleared.
         val loaded = storageManager.loadIdentity()
-        Assert.assertNull(loaded)
+        assertNull(loaded.first)
+        assertEquals(NO_IDENTITY, loaded.second)
         verify(editor).clear()
     }
 }


### PR DESCRIPTION
This PR will add support to persist (and restore) what the previous IdentityStatus is. This is useful to ensure that in the case when a `OPT_OUT` is associated with the user, that this is consistently reported across app launches. 