### PR TITLE
Add support to deploy IMA/GMA plugins

### DIFF
--- a/pom.gradle
+++ b/pom.gradle
@@ -1,0 +1,27 @@
+
+mavenPublishing {
+    pom {
+        name = project.name
+        description = 'A framework for integration UID2 into Android applications.'
+        url = 'https://github.com/IABTechLab/uid2-android-sdk'
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = 'IABTechLab'
+                name = 'IAB Tech Lab'
+                url = 'https://iabtechlab.com/'
+            }
+        }
+        scm {
+            url = 'https://github.com/IABTechLab/uid2-android-sdk'
+            connection = 'scm:git:git@github.com:IABTechLab/uid2-android-sdk.git'
+            developerConnection = 'scm:git:ssh://git@github.com:IABTechLab/uid2-android-sdk.git'
+        }
+    }
+}

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -69,34 +69,11 @@ tasks.register('dokkaJavadocJar', Jar.class) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Maven Publishing
 
+apply from:  rootProject.file("$rootDir/pom.gradle")
+
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.S01, true)
     signAllPublications()
 
     coordinates(project.group, "uid2-android-sdk", project.version)
-
-    pom {
-        name = project.name
-        description = 'A framework for integration UID2 into Android applications.'
-        url = 'https://github.com/IABTechLab/uid2-android-sdk'
-        licenses {
-            license {
-                name = "The Apache License, Version 2.0"
-                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                distribution = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        }
-        developers {
-            developer {
-                id = 'IABTechLab'
-                name = 'IAB Tech Lab'
-                url = 'https://iabtechlab.com/'
-            }
-        }
-        scm {
-            url = 'https://github.com/IABTechLab/uid2-android-sdk'
-            connection = 'scm:git:git@github.com:IABTechLab/uid2-android-sdk.git'
-            developerConnection = 'scm:git:ssh://git@github.com:IABTechLab/uid2-android-sdk.git'
-        }
-    }
 }

--- a/securesignals-gma/build.gradle
+++ b/securesignals-gma/build.gradle
@@ -1,6 +1,9 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.vanniktech.maven.publish'
 }
 
 apply from:  rootProject.file("$rootDir/common.gradle")
@@ -27,4 +30,16 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.android.gms:play-services-ads:21.5.0'
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Maven Publishing
+
+apply from:  rootProject.file("$rootDir/pom.gradle")
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.S01, true)
+    signAllPublications()
+
+    coordinates(project.group, "uid2-android-sdk-gma", project.version)
 }

--- a/securesignals-ima/build.gradle
+++ b/securesignals-ima/build.gradle
@@ -1,6 +1,9 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.vanniktech.maven.publish'
 }
 
 apply from:  rootProject.file("$rootDir/common.gradle")
@@ -27,4 +30,16 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Maven Publishing
+
+apply from:  rootProject.file("$rootDir/pom.gradle")
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.S01, true)
+    signAllPublications()
+
+    coordinates(project.group, "uid2-android-sdk-ima", project.version)
 }


### PR DESCRIPTION
Added maven publication support for the IMA and GMA plugins. They just use a shared pom, since they don't really need anything more specific. The artefact ids are as follows:
 - uid2-android-sdk
 - uid2-android-sdk-ima
 - uid2-android-sdk-gma

For testing, I temporarily modified the `publish.yml` to include this branch. I was able to successfully deploy a snapshot from all three modules.