### PR TITLE
Detect expiration times and notify observers

### DIFF
--- a/dev-app/src/main/java/com/uid2/dev/ui/MainScreenViewModel.kt
+++ b/dev-app/src/main/java/com/uid2/dev/ui/MainScreenViewModel.kt
@@ -62,7 +62,7 @@ class MainScreenViewModel(
                     is Established -> _viewState.emit(UserUpdatedState(state.identity, ESTABLISHED))
                     is Refreshed -> _viewState.emit(UserUpdatedState(state.identity, REFRESHED))
                     is NoIdentity -> _viewState.emit(UserUpdatedState(null, NO_IDENTITY))
-                    is Expired -> _viewState.emit(UserUpdatedState(null, EXPIRED))
+                    is Expired -> _viewState.emit(UserUpdatedState(state.identity, EXPIRED))
                     is RefreshExpired -> _viewState.emit(UserUpdatedState(null, REFRESH_EXPIRED))
                     is OptOut -> _viewState.emit(UserUpdatedState(null, OPT_OUT))
                     else ->  _viewState.emit(UserUpdatedState(null, INVALID))


### PR DESCRIPTION
Since the `UID2Manager` is designed to be reactive, I wanted to introduce a mechanism to detect when it's status changes to `Expired` and also `RefreshExpires`. This is decoupled from the general refresh logic, as that can be enabled or disabled by the user.

This PR adds a simple mechanism to schedule when the manager will check for expiration. While implementing it, I also found a number of issues which have been fixed.