### PR TITLE
Fix minor issues and test Snapshots

### DIFF
--- a/sdk/src/main/java/com/uid2/UID2Manager.kt
+++ b/sdk/src/main/java/com/uid2/UID2Manager.kt
@@ -376,7 +376,7 @@ class UID2Manager internal constructor(
         // The additional time we will allow to pass before checking the expiration of the Identity.
         private const val EXPIRATION_CHECK_TOLERANCE_MS = 50
 
-        private var api: String = UID2_API_URL_KEY
+        private var api: String = UID2_API_URL_DEFAULT
         private var networkSession: NetworkSession = DefaultNetworkSession()
         private var storageManager: StorageManager? = null
 
@@ -389,7 +389,7 @@ class UID2Manager internal constructor(
         fun init(context: Context) = init(context, DefaultNetworkSession())
 
         /**
-         * Initializes the class with the given [Context], along with a @see NetworkSession that will be responsible
+         * Initializes the class with the given [Context], along with a [NetworkSession] that will be responsible
          * for making any required network calls.
          *
          * @param context The context to initialise from. This will be used to obtain the package's metadata to extract

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+
+        // Required when testing a Snapshot build from the DevApp.
+        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
     }
 }
 rootProject.name = "UID2 Android SDK"


### PR DESCRIPTION
Identified a few small tweaks that needed to be made while testing the consumption of a Snapshot build from the DevApp. Since a Snapshot comes from a different repository than (Normal) MavenCentral, I had to add the extra repository. This is what is required to test the Dev App:

```
diff --git a/dev-app/build.gradle b/dev-app/build.gradle
index 46258e2..f6fe1d8 100644
--- a/dev-app/build.gradle
+++ b/dev-app/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':sdk')
+    implementation 'com.uid2:uid2-android-sdk:0.1.0-SNAPSHOT'
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
```