### PR TITLE
Bump IMA SDK to 3.30.1

### DIFF
--- a/securesignals-ima-dev-app/build.gradle
+++ b/securesignals-ima-dev-app/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    compileOnly project(path: ':securesignals-ima')
+    implementation project(path: ':securesignals-ima')
     compileOnly 'com.uid2:uid2-android-sdk:0.1.0'
     compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
 

--- a/securesignals-ima-dev-app/build.gradle
+++ b/securesignals-ima-dev-app/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':securesignals-ima')
+    compileOnly project(path: ':securesignals-ima')
     implementation 'com.uid2:uid2-android-sdk:0.1.0'
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
 

--- a/securesignals-ima-dev-app/build.gradle
+++ b/securesignals-ima-dev-app/build.gradle
@@ -30,8 +30,8 @@ android {
 
 dependencies {
     implementation project(path: ':securesignals-ima')
-    compileOnly 'com.uid2:uid2-android-sdk:0.1.0'
-    compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
+    implementation 'com.uid2:uid2-android-sdk:0.1.0'
+    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
 
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/securesignals-ima-dev-app/build.gradle
+++ b/securesignals-ima-dev-app/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation project(path: ':securesignals-ima')
     compileOnly 'com.uid2:uid2-android-sdk:0.1.0'
-    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
+    compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
 
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/securesignals-ima-dev-app/build.gradle
+++ b/securesignals-ima-dev-app/build.gradle
@@ -30,8 +30,8 @@ android {
 
 dependencies {
     compileOnly project(path: ':securesignals-ima')
-    implementation 'com.uid2:uid2-android-sdk:0.1.0'
-    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
+    compileOnly 'com.uid2:uid2-android-sdk:0.1.0'
+    compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
 
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/securesignals-ima-dev-app/src/main/AndroidManifest.xml
+++ b/securesignals-ima-dev-app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".IMADevApplication"

--- a/securesignals-ima/build.gradle
+++ b/securesignals-ima/build.gradle
@@ -23,10 +23,10 @@ android {
 
 dependencies {
     implementation project(path: ':sdk')
-    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
+    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
+    testImplementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Restore IMA SDK to 3.30.x level now that issue concerning crashes on non Android TV devices has been resolved with 3.30.1.

https://developers.google.com/interactive-media-ads/docs/sdks/android/client-side/history

<img width="884" alt="Screenshot 2023-04-21 at 11 34 00 PM" src="https://user-images.githubusercontent.com/989928/233762728-a99aa59b-294d-4e23-a8c6-617db2a5315b.png">
