### PR TITLE
Remove requirement for Application Metadata

### DIFF
--- a/dev-app/src/main/AndroidManifest.xml
+++ b/dev-app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:supportsRtl="true"
         tools:targetApi="31">
 
-        <!-- The metadata consumed by the Dev App + SDK-->
+        <!-- The metadata consumed by the Dev App + SDK -->
         <meta-data android:name="uid2_api_url" android:value="https://operator-integ.uidapi.com"/>
         <meta-data android:name="uid2_api_key" android:value=""/>
         <meta-data android:name="uid2_api_secret" android:value=""/>

--- a/sdk/src/main/java/com/uid2/UID2Manager.kt
+++ b/sdk/src/main/java/com/uid2/UID2Manager.kt
@@ -406,7 +406,7 @@ class UID2Manager internal constructor(
 
             val metadata = context.getMetadata()
 
-            this.api = metadata.getString(UID2_API_URL_KEY, UID2_API_URL_DEFAULT)
+            this.api = metadata?.getString(UID2_API_URL_KEY, UID2_API_URL_DEFAULT) ?: UID2_API_URL_DEFAULT
             this.networkSession = networkSession
             this.storageManager = StorageManager.getInstance(context)
         }

--- a/sdk/src/main/java/com/uid2/extensions/ContextEx.kt
+++ b/sdk/src/main/java/com/uid2/extensions/ContextEx.kt
@@ -9,7 +9,7 @@ import android.os.Bundle
 /**
  * Helper method to extract the MetaData Bundle associated with the given Context.
  */
-internal fun Context.getMetadata(): Bundle = packageManager.getApplicationInfoCompat(
+internal fun Context.getMetadata(): Bundle? = packageManager.getApplicationInfoCompat(
     packageName,
     PackageManager.GET_META_DATA
 ).metaData


### PR DESCRIPTION
The SDK includes a default value for the API URL which potentially could be overwritten by the consuming app. However, it's entirely possible the app doesn't want/need to change it, meaning that it could not have **any** metadata associated with it. In this scenario, the SDK should not crash and should silently just use the default.