### PR TITLE
Avoid race condition with initialization

### DIFF
--- a/sdk/src/test/java/com/uid2/UID2ManagerTest.kt
+++ b/sdk/src/test/java/com/uid2/UID2ManagerTest.kt
@@ -108,6 +108,22 @@ class UID2ManagerTest {
     }
 
     @Test
+    fun `resets identity immediately after initialisation`() = runTest(testDispatcher) {
+        // Create a new instance of the manager but *don't* allow it to finish initialising (loading previous identity)
+        val manager = UID2Manager(client, storageManager, timeUtils, testDispatcher, false).apply {
+            onIdentityChangedListener = listener
+            checkExpiration = false
+        }
+
+        // Reset the Manager's identity
+        manager.resetIdentity()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Verify that the Manager updated with the reset identity and reported the state changes appropriately.
+        assertManagerState(manager, null, NO_IDENTITY)
+    }
+
+    @Test
     fun `refresh no-op when no identity`() {
         val manager = withManager(client, mock(), timeUtils, testDispatcher, false, null)
         assertNull(manager.currentIdentity)


### PR DESCRIPTION
I found that we were exposed to a number of race conditions, caused by the following:
 - The consuming app initialises the manager
 - The manager internally kicks off an async task to load state from storage
 - If the consuming app **immediately** calls our public API, this can happen **before** we have loaded our initial state
 - The initial state will overwrite any modified state set by the consuming app.

This workaround ensures that all public interfaces are aware of the initialisation of the manager. If they occur before, they are suspended until we are ready.