### PR TITLE
Fix version parsing for SDK and Plugins

### DIFF
--- a/sdk/src/main/java/com/uid2/UID2.kt
+++ b/sdk/src/main/java/com/uid2/UID2.kt
@@ -11,9 +11,6 @@ data class Version(val major: Int, val minor: Int, val patch: Int)
 object UID2 {
     private const val VERSION_STRING = BuildConfig.VERSION
 
-    private const val VERSION_COMPONENTS = 3
-    private val INVALID_VERSION = Version(0, 0, 0)
-
     /**
      * Gets the version of the included UID2 SDK library, in string format.
      */
@@ -22,12 +19,24 @@ object UID2 {
     /**
      * Gets the version of the included UID2 SDK library, in its individual major, minor and patch components.
      */
-    fun getVersionInfo(): Version {
-        val components = VERSION_STRING.split(".")
+    fun getVersionInfo() = VersionParser.parseVersion(VERSION_STRING)
+}
+
+object VersionParser {
+    private const val VERSION_COMPONENTS = 3
+    internal val INVALID_VERSION = Version(0, 0, 0)
+
+    fun parseVersion(original: String): Version {
+        // Remove any -SNAPSHOT postfix. These builds shouldn't be used in production, but are in tests.
+        val version = original.split("-").first()
+
+        val components = version.split(".")
         if (components.size != VERSION_COMPONENTS) {
             return INVALID_VERSION
         }
 
-        return Version(components[0].toInt(), components[0].toInt(), components[0].toInt())
+        return runCatching {
+            Version(components[0].toInt(), components[1].toInt(), components[2].toInt())
+        }.getOrDefault(INVALID_VERSION)
     }
 }

--- a/sdk/src/test/java/com/uid2/VersionParserTest.kt
+++ b/sdk/src/test/java/com/uid2/VersionParserTest.kt
@@ -1,0 +1,43 @@
+package com.uid2
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VersionParserTest {
+
+    @Test
+    fun `test invalid versions`() {
+        listOf(
+            "1.0",
+            "a.b.c",
+            "1.0.1.1"
+        ).forEach {
+            val version = VersionParser.parseVersion(it)
+            assertEquals(VersionParser.INVALID_VERSION, version)
+        }
+    }
+
+    @Test
+    fun `test valid version`() {
+        val major = 1
+        val minor = 2
+        val patch = 3
+
+        val version = VersionParser.parseVersion("$major.$minor.$patch")
+        assertEquals(major, version.major)
+        assertEquals(minor, version.minor)
+        assertEquals(patch, version.patch)
+    }
+
+    @Test
+    fun `test snapshot builds`() {
+        val major = 1
+        val minor = 2
+        val patch = 3
+
+        val version = VersionParser.parseVersion("$major.$minor.$patch-SNAPSHOT")
+        assertEquals(major, version.major)
+        assertEquals(minor, version.minor)
+        assertEquals(patch, version.patch)
+    }
+}

--- a/securesignals-gma/src/main/java/com/uid2/securesignals/gma/PluginVersion.kt
+++ b/securesignals-gma/src/main/java/com/uid2/securesignals/gma/PluginVersion.kt
@@ -1,7 +1,7 @@
 package com.uid2.securesignals.gma
 
 import com.uid2.BuildConfig
-import com.uid2.Version
+import com.uid2.VersionParser
 
 /**
  * An object exposing the version information associated with the UID2 GMA Plugin.
@@ -9,18 +9,8 @@ import com.uid2.Version
 internal object PluginVersion {
     private const val VERSION_STRING = BuildConfig.VERSION
 
-    private const val VERSION_COMPONENTS = 3
-    private val INVALID_VERSION = Version(0, 0, 0)
-
     /**
      * Gets the version of the included UID2/IMA plugin, in its individual major, minor and patch components.
      */
-    fun getVersionInfo(): Version {
-        val components = VERSION_STRING.split(".")
-        if (components.size != VERSION_COMPONENTS) {
-            return INVALID_VERSION
-        }
-
-        return Version(components[0].toInt(), components[0].toInt(), components[0].toInt())
-    }
+    fun getVersionInfo() = VersionParser.parseVersion(VERSION_STRING)
 }

--- a/securesignals-ima/src/main/java/com/uid2/securesignals/ima/PluginVersion.kt
+++ b/securesignals-ima/src/main/java/com/uid2/securesignals/ima/PluginVersion.kt
@@ -1,7 +1,7 @@
 package com.uid2.securesignals.ima
 
 import com.uid2.BuildConfig
-import com.uid2.Version
+import com.uid2.VersionParser
 
 /**
  * An object exposing the version information associated with the UID2 IMA Plugin.
@@ -9,18 +9,8 @@ import com.uid2.Version
 internal object PluginVersion {
     private const val VERSION_STRING = BuildConfig.VERSION
 
-    private const val VERSION_COMPONENTS = 3
-    private val INVALID_VERSION = Version(0, 0, 0)
-
     /**
      * Gets the version of the included UID2/IMA plugin, in its individual major, minor and patch components.
      */
-    fun getVersionInfo(): Version {
-        val components = VERSION_STRING.split(".")
-        if (components.size != VERSION_COMPONENTS) {
-            return INVALID_VERSION
-        }
-
-        return Version(components[0].toInt(), components[0].toInt(), components[0].toInt())
-    }
+    fun getVersionInfo() = VersionParser.parseVersion(VERSION_STRING)
 }


### PR DESCRIPTION
After testing, we've identified that the version parsing wasn't correct. Looks like a silly mistake, and since we have three separate components all using the same code to parse, the bug was in three places :/ 