### PR TITLE
Add proguard configuration for IMA/GMA plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ A framework for integrating [UID2](https://github.com/IABTechLab/uid2docs) into 
 
 The UID2 SDK is a standalone headless library defined and published via Maven Central.  As such the `dev-app` is the primary way for developing the SDK.  Use Android Studio to open the root folder to begin development.
 
+R8 / ProGuard
+-------------
+If you are using R8 the shrinking and obfuscation rules are included automatically.
+
+ProGuard users must manually add the options from
+[uid2-gma.pro](https://github.com/IABTechLab/uid2-android-sdk/blob/main/securesignals-gma/uid2-gma.pro) and [uid2-ima.pro](https://github.com/IABTechLab/uid2-android-sdk/blob/main/securesignals-ima/uid2-ima.pro).
+
 ## License
 
 UID2 is released under the Apache license. [See LICENSE](https://github.com/IABTechLab/uid2-android-sdk/blob/main/LICENSE.md) for details.

--- a/sdk/src/test/java/com/uid2/network/RefreshResponseTest.kt
+++ b/sdk/src/test/java/com/uid2/network/RefreshResponseTest.kt
@@ -19,8 +19,7 @@ class RefreshResponseTest {
             JSONObject(),
             JSONObject(mapOf("key" to "value"))
         ).forEach {
-            val refresh = RefreshResponse.fromJson(it)
-            assertNull(refresh)
+            assertNull(RefreshResponse.fromJson(it))
         }
 
         // If we take a valid response but remove the "status" parameter, check that it's handled correctly.
@@ -45,8 +44,7 @@ class RefreshResponseTest {
 
             body.remove(it)
 
-            val refresh = RefreshResponse.fromJson(success)
-            assertNull(refresh)
+            assertNull(RefreshResponse.fromJson(success))
         }
     }
 

--- a/securesignals-gma-dev-app/build.gradle
+++ b/securesignals-gma-dev-app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from:  rootProject.file("$rootDir/common.gradle")
 
 android {
-    namespace 'com.uid2.devapp'
+    namespace 'com.uid2.dev'
 
     defaultConfig {
         applicationId "com.uid2.securesignals.gma.devapp"
@@ -17,7 +17,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            shrinkResources true
+            minifyEnabled true
         }
     }
 

--- a/securesignals-gma-dev-app/src/main/java/com/uid2/dev/BannerActivity.java
+++ b/securesignals-gma-dev-app/src/main/java/com/uid2/dev/BannerActivity.java
@@ -15,7 +15,6 @@ import com.google.android.gms.ads.initialization.InitializationStatus;
 import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 import com.uid2.UID2Manager;
 import com.uid2.data.UID2Identity;
-import com.uid2.devapp.R;
 
 import org.json.JSONObject;
 

--- a/securesignals-gma/build.gradle
+++ b/securesignals-gma/build.gradle
@@ -16,6 +16,7 @@ android {
 
     buildTypes {
         release {
+            consumerProguardFiles 'uid2-gma.pro'
             minifyEnabled false
         }
     }

--- a/securesignals-gma/uid2-gma.pro
+++ b/securesignals-gma/uid2-gma.pro
@@ -1,0 +1,3 @@
+# Google's GMA uses reflection to identify available adapters. These are therefore not referenced by the consuming
+# application and thus, require a rule to ensure that they are not stripped out during the build.
+-keep public class com.uid2.securesignals.gma.*

--- a/securesignals-ima/build.gradle
+++ b/securesignals-ima/build.gradle
@@ -16,6 +16,7 @@ android {
 
     buildTypes {
         release {
+            consumerProguardFiles 'uid2-ima.pro'
             minifyEnabled false
         }
     }

--- a/securesignals-ima/uid2-ima.pro
+++ b/securesignals-ima/uid2-ima.pro
@@ -1,0 +1,3 @@
+# Google's IMA uses reflection to identify available adapters. These are therefore not referenced by the consuming
+# application and thus, require a rule to ensure that they are not stripped out during the build.
+-keep public class com.uid2.securesignals.ima.*


### PR DESCRIPTION
Since IMA/GMA will load our adapters via reflection, we need to make sure Proguard is configured to avoid these classes being stripped out. The embedded configuration files will be picked up automatically by R8, however, for older builds that use Proguard directly, we will need to update the support documentation to reference them.