### PR TITLE
Improve automatic refresh behaviour and avoid exception when fails

### DIFF
--- a/securesignals-ima-dev-app/build.gradle
+++ b/securesignals-ima-dev-app/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation project(path: ':securesignals-ima')
     compileOnly 'com.uid2:uid2-android-sdk:0.1.0'
-    compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
+    compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
 
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/securesignals-ima/build.gradle
+++ b/securesignals-ima/build.gradle
@@ -22,8 +22,8 @@ android {
 
 dependencies {
     implementation project(path: ':sdk')
-    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
+    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.30.1'
+    testImplementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
 }

--- a/securesignals-ima/lint-baseline.xml
+++ b/securesignals-ima/lint-baseline.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="6" by="lint 7.4.2" type="baseline" client="gradle" dependencies="true" name="AGP (7.4.2)" variant="all" version="7.4.2">
 
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.ads.interactivemedia.v3:interactivemedia than 3.29.0 is available: 3.30.1"
+        errorLine1="    implementation &apos;com.google.ads.interactivemedia.v3:interactivemedia:3.29.0&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="25"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.ads.interactivemedia.v3:interactivemedia than 3.29.0 is available: 3.30.1"
+        errorLine1="    testImplementation &apos;com.google.ads.interactivemedia.v3:interactivemedia:3.29.0&apos;"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="28"
+            column="24"/>
+    </issue>
+
 </issues>


### PR DESCRIPTION
This PR includes the following:
 - When we are automatically refreshing, there is a point when we can't/shouldn't refresh any further. This used to result in an exception being thrown in one of our coroutines, and since there is no `CoroutineExceptionHandler`, this resulted in a fatal exception.
 - As requested by @sunnywu, we have changed the refresh behaviour to only stop retrying once the associated identity has expired (fully) and therefore refreshing is not possible. We've also changed the period between refresh attempts, to increase to 60 seconds, after 5 consecutive failures
 - Google have deprecated IMA 3.31.X and therefore we are required to downgrade back to the latest stable build, which is 3.29.0