### PR TITLE
Enable explicitApi for SDK modules

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -26,6 +26,10 @@ android {
             }
         }
     }
+
+    kotlin {
+        explicitApi()
+    }
 }
 
 dependencies {

--- a/securesignals-gma/build.gradle
+++ b/securesignals-gma/build.gradle
@@ -18,6 +18,10 @@ android {
             minifyEnabled false
         }
     }
+
+    kotlin {
+        explicitApi()
+    }
 }
 
 dependencies {

--- a/securesignals-ima/build.gradle
+++ b/securesignals-ima/build.gradle
@@ -18,6 +18,10 @@ android {
             minifyEnabled false
         }
     }
+
+    kotlin {
+        explicitApi()
+    }
 }
 
 dependencies {


### PR DESCRIPTION
As suggested by @koalaparadise, we should enable `explicitApi` for our SDK based modules. More information about it can be found here: https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors