### PR TITLE
Enable automatic tagged releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@ VERSION_NAME=0.5.0-SNAPSHOT
 
 SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
+# Enable automatic tagged releases
+SONATYPE_AUTOMATIC_RELEASE=true
 
 POM_INCEPTION_YEAR=2023
 POM_URL=https://github.com/IABTechLab/uid2-android-sdk


### PR DESCRIPTION
This means that publishing is now fully automatic, after being initiated from GitHub.