### PR TITLE
Add ability to query if identity is available

### DIFF
--- a/sdk/src/main/java/com/uid2/UID2Manager.kt
+++ b/sdk/src/main/java/com/uid2/UID2Manager.kt
@@ -123,6 +123,12 @@ public class UID2Manager internal constructor(
         }
 
     /**
+     * Gets whether or not [UID2Manager] has a known [UID2Identity]. If not, a new identity should be generated and set
+     * via [setIdentity].
+     */
+    public fun hasIdentity(): Boolean = currentIdentity != null
+
+    /**
      * Gets the current Identity Status.
      */
     public val currentIdentityStatus: IdentityStatus


### PR DESCRIPTION
This PR adds a new public API to explicitly query if the `UID2Manager` has a known (and valid) identity. The identity may potentially need to be refreshed, but as long as it can, `hasIdentity` will return `true`.

I've also added unit test coverage for a number of the different common cases.