### PR TITLE
[Dependencies] Bump AGP (8.4.0)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.2"
+agp = "8.4.0"
 kotlin = "1.9.23"
 core-ktx = "1.13.0"
 junit = "4.13.2"


### PR DESCRIPTION
Bumping the Android Gradle Plugin to 8.4.0