### PR TITLE
[Actions] Update release action when setting up gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
 
-      - uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build and run tests
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,8 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - uses: gradle/gradle-build-action@v3
-        with:
-          # Disable writing to cache. Don't want to spoil the main cache
-          cache-read-only: true
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Get Snaptshot versions
         id: snapshotVersions


### PR DESCRIPTION
This updates the gradle setup action, as recommended by: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle