### PR TITLE
Improve public key validation

### DIFF
--- a/sdk/src/main/java/com/uid2/utils/KeyUtils.kt
+++ b/sdk/src/main/java/com/uid2/utils/KeyUtils.kt
@@ -56,6 +56,13 @@ internal interface KeyUtils {
         }
 
         override fun generateServerPublicKey(publicKey: String): PublicKey? {
+            // Check to make sure the given public key is longer than the expected prefix.
+            if (publicKey.length <= SERVER_PUBLIC_KEY_PREFIX_LENGTH) {
+                return null
+            }
+
+            // Attempt to decode the given public key. If the key is malformed, or not in the expected Base64 format,
+            // null we be returned.
             val serverPublicKeyBytes =
                 publicKey.substring(SERVER_PUBLIC_KEY_PREFIX_LENGTH).decodeBase64() ?: return null
 


### PR DESCRIPTION
This fixes an issue if the caller accidentally passes in an invalid public key parameter. We will now handle malformed input.

I would have also liked this to be under a UT, but since it's part of the `KeyUtils`, this internally is using a lot of Java/Android crypto stuff which is not mockable (hence why this class exists, to control their usage).