### PR TITLE
Improve error reporting by including optional error message

### DIFF
--- a/sdk/src/main/java/com/uid2/UID2Client.kt
+++ b/sdk/src/main/java/com/uid2/UID2Client.kt
@@ -111,8 +111,8 @@ internal class UID2Client(
         // Attempt to make the request via the provided NetworkSession.
         val response = session.loadData(url, request)
         if (response.code != HttpURLConnection.HTTP_OK) {
-            logger.e(TAG) { "Client details failure: ${response.code}" }
-            throw RequestFailureException(response.code)
+            logger.e(TAG) { "Client details failure: ${response.code} ${response.data}" }
+            throw RequestFailureException(response.code, response.data)
         }
 
         // The response should be an encrypted payload. Let's attempt to decrypt it using the key we were provided.

--- a/sdk/src/main/java/com/uid2/UID2Exception.kt
+++ b/sdk/src/main/java/com/uid2/UID2Exception.kt
@@ -28,7 +28,7 @@ public class InputValidationException(description: String?) : UID2Exception(desc
 /**
  * An attempt was made to the API that resulted in a failure.
  */
-internal class RequestFailureException(val statusCode: Int) : UID2Exception()
+internal class RequestFailureException(val statusCode: Int, message: String? = null) : UID2Exception(message)
 
 /**
  * The encrypted payload could not be decrypted successfully.

--- a/sdk/src/main/java/com/uid2/network/NetworkSession.kt
+++ b/sdk/src/main/java/com/uid2/network/NetworkSession.kt
@@ -57,4 +57,16 @@ public interface NetworkSession {
      * @return The [NetworkResponse] which contains the outcome of the attempted request.
      */
     public fun loadData(url: URL, request: NetworkRequest): NetworkResponse
+
+    public companion object {
+        private const val SUCCESS_CODE_RANGE_MIN = 200
+        private const val SUCCESS_CODE_RANGE_MAX = 299
+
+        /**
+         * Function to determine if a given response code is considered a "success".
+         */
+        @JvmStatic
+        public fun isSuccess(responseCode: Int): Boolean =
+            responseCode in SUCCESS_CODE_RANGE_MIN..SUCCESS_CODE_RANGE_MAX
+    }
 }


### PR DESCRIPTION
This PR includes the following:
 - We now extract any response text included in a response that's associated with a HTTP failure
 - We now both log and include any error response text in the exception raised by the SDK
 - I added some additional error handling that I took from the OpenPass SDK, to ensure we catch all potential IOException's