### PR TITLE
Migrate Unit Tests to MockK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.1"
+agp = "8.4.2"
 kotlin = "2.0.0"
 core-ktx = "1.13.1"
 junit = "4.13.2"
@@ -10,6 +10,7 @@ compose-bom = "2024.05.00"
 compose-tooling = "1.6.7"
 gma = "23.1.0"
 ima = "3.33.0"
+mockkVersion = "1.13.11"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -41,8 +42,8 @@ androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", ve
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines-version" }
 json = { group = "org.json", name = "json", version = "20240303" }
-mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "4.1.0" }
-mockito-inline = { group = "org.mockito", name = "mockito-inline", version = "4.8.0" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockkVersion" }
+mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockkVersion" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -35,8 +35,8 @@ android {
 dependencies {
     testImplementation(libs.junit)
 
-    testImplementation(libs.mockito.kotlin)
-    testImplementation(libs.mockito.inline)
+    testImplementation(libs.mockk.android)
+    testImplementation(libs.mockk.agent)
 
     testImplementation(libs.json)
 }

--- a/sdk/src/test/java/com/uid2/extensions/StringExTest.kt
+++ b/sdk/src/test/java/com/uid2/extensions/StringExTest.kt
@@ -5,11 +5,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
 import java.util.Base64
 
-@RunWith(MockitoJUnitRunner::class)
 class StringExTest {
 
     @Test

--- a/sdk/src/test/java/com/uid2/storage/FileStorageManagerTest.kt
+++ b/sdk/src/test/java/com/uid2/storage/FileStorageManagerTest.kt
@@ -5,29 +5,19 @@ import com.uid2.data.IdentityStatus.NO_IDENTITY
 import com.uid2.data.UID2Identity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
 import java.io.File
 
 @ExperimentalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
 class FileStorageManagerTest {
-    private lateinit var testDispatcher: TestDispatcher
+    private val testDispatcher = StandardTestDispatcher()
 
     private val identityFile: File = File("test_identity.json")
-
-    @Before
-    fun before() {
-        testDispatcher = StandardTestDispatcher()
-    }
 
     @After
     fun after() {

--- a/sdk/src/test/java/com/uid2/utils/InputUtilsTest.kt
+++ b/sdk/src/test/java/com/uid2/utils/InputUtilsTest.kt
@@ -5,10 +5,7 @@ import com.uid2.data.IdentityRequest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 class InputUtilsTest {
 
     @Test


### PR DESCRIPTION
We are now using MockK for mocking, instead of Mockito. One of the main drivers for this is that we were stuck on an older version of Mockito, due to JVM versions. I had wanted to use MockK instead of a while, so decided to do this to allow us to be running the latest version - before we enable renovate.