### PR TITLE
Refactor to allow multiple initialization listeners to be attached

### DIFF
--- a/securesignals-gma/src/main/java/com/uid2/securesignals/gma/UID2MediationAdapter.kt
+++ b/securesignals-gma/src/main/java/com/uid2/securesignals/gma/UID2MediationAdapter.kt
@@ -48,7 +48,7 @@ public class UID2MediationAdapter : RtbAdapter() {
         // After we've asked to initialize the manager, we should wait until it's complete before reporting success.
         // This will potentially allow any previously persisted identity to be fully restored before we allow any
         // signals to be collected.
-        UID2Manager.getInstance().onInitialized = initializationCompleteCallback::onInitializationSucceeded
+        UID2Manager.getInstance().addOnInitializedListener(initializationCompleteCallback::onInitializationSucceeded)
     }
 
     /**

--- a/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignalsAdapter.kt
+++ b/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignalsAdapter.kt
@@ -44,7 +44,7 @@ public class UID2SecureSignalsAdapter : SecureSignalsAdapter {
         // After we've asked to initialize the manager, we should wait until it's complete before reporting success.
         // This will potentially allow any previously persisted identity to be fully restored before we allow any
         // signals to be collected.
-        UID2Manager.getInstance().onInitialized = callback::onSuccess
+        UID2Manager.getInstance().addOnInitializedListener(callback::onSuccess)
     }
 
     /**


### PR DESCRIPTION
This allows for multiple listeners to be attached to the same event, avoiding multiple uses of it clashing.