### PR TITLE
Upgrade AGP

### DIFF
--- a/dev-app/build.gradle
+++ b/dev-app/build.gradle
@@ -33,6 +33,7 @@ android {
     }
 
     lint {
+        baseline = file("lint-baseline.xml")
         disable 'GradleDependency'
     }
 }

--- a/dev-app/lint-baseline.xml
+++ b/dev-app/lint-baseline.xml
@@ -1,22 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 7.4.2" type="baseline" client="gradle" dependencies="true" name="AGP (7.4.2)" variant="all" version="7.4.2">
+<issues format="6" by="lint 8.6.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.6.0)" variant="all" version="8.6.0">
 
     <issue
-        id="DataExtractionRules"
-        message="The attribute `android:allowBackup` is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute `android:dataExtractionRules` specifying an `@xml` resource which configures cloud backups and device transfers on Android 12 and higher."
-        errorLine1="        android:allowBackup=&quot;false&quot;"
-        errorLine2="                             ~~~~~">
+        id="WrongConstant"
+        message="Must be one or more of: PackageManager.GET_META_DATA, PackageManager.GET_SHARED_LIBRARY_FILES, PackageManager.MATCH_UNINSTALLED_PACKAGES, PackageManager.MATCH_SYSTEM_ONLY, PackageManager.MATCH_DISABLED_COMPONENTS, PackageManager.MATCH_DISABLED_UNTIL_USED_COMPONENTS, PackageManager.GET_DISABLED_UNTIL_USED_COMPONENTS, PackageManager.GET_UNINSTALLED_PACKAGES, PackageManager.MATCH_APEX"
+        errorLine1="                getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(flags.toLong()))"
+        errorLine2="                                                                                       ~~~~~~~~~~~~~~">
         <location
-            file="src/main/AndroidManifest.xml"
-            line="12"
-            column="30"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.mipmap.ic_launcher_round` appears to be unused">
-        <location
-            file="src/main/res/mipmap-hdpi/ic_launcher_round.webp"/>
+            file="src/main/java/com/uid2/dev/network/AppUID2Client.kt"
+            line="202"
+            column="88"/>
     </issue>
 
 </issues>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.2"
+agp = "8.6.0"
 kotlin = "2.0.0"
 core-ktx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
- Upgrade AGP 8.5.2 -> 8.6.0 
- Add a lint exception to the baseline to ignore what appears to be a false positive