### PR TITLE
EUID Support for IMA Plugin

### DIFF
--- a/securesignals-ima-dev-app/src/main/AndroidManifest.xml
+++ b/securesignals-ima-dev-app/src/main/AndroidManifest.xml
@@ -14,6 +14,9 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="UnusedAttribute">
 
+        <!-- Metadata for toggling UID2 and EUID environments. If true, EUID is used. -->
+        <meta-data android:name="uid2_environment_euid" android:value="false"/>
+
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"

--- a/securesignals-ima-dev-app/src/main/java/com/uid2/dev/IMADevApplication.kt
+++ b/securesignals-ima-dev-app/src/main/java/com/uid2/dev/IMADevApplication.kt
@@ -2,8 +2,11 @@ package com.uid2.dev
 
 import android.app.Application
 import android.util.Log
+import com.uid2.EUIDManager
 import com.uid2.UID2Manager
 import com.uid2.UID2Manager.Environment.Production
+import com.uid2.dev.utils.getMetadata
+import com.uid2.dev.utils.isEnvironmentEUID
 
 class IMADevApplication : Application() {
 
@@ -13,11 +16,18 @@ class IMADevApplication : Application() {
         // Initialise the UID2Manager class. We will use it's DefaultNetworkSession rather than providing our own
         // custom implementation. This can be done to allow wrapping something like OkHttp.
         try {
-            UID2Manager.init(
-                context = this,
-                environment = Production,
-                isLoggingEnabled = true,
-            )
+            if (baseContext.getMetadata().isEnvironmentEUID()) {
+                EUIDManager.init(
+                    context = this,
+                    isLoggingEnabled = true,
+                )
+            } else {
+                UID2Manager.init(
+                    context = this,
+                    environment = Production,
+                    isLoggingEnabled = true,
+                )
+            }
         } catch (ex: Exception) {
             Log.e("IMADevApplication", "Error initialising UID2Manager", ex)
         }

--- a/securesignals-ima-dev-app/src/main/java/com/uid2/dev/MainActivity.java
+++ b/securesignals-ima-dev-app/src/main/java/com/uid2/dev/MainActivity.java
@@ -1,5 +1,8 @@
 package com.uid2.dev;
 
+import static com.uid2.dev.utils.BundleExKt.isEnvironmentEUID;
+import static com.uid2.dev.utils.ContextExKt.getMetadata;
+
 import android.content.Context;
 import android.media.AudioManager;
 import android.os.Bundle;
@@ -22,6 +25,7 @@ import com.google.ads.interactivemedia.v3.api.AdsRequest;
 import com.google.ads.interactivemedia.v3.api.ImaSdkFactory;
 import com.google.ads.interactivemedia.v3.api.ImaSdkSettings;
 import com.google.ads.interactivemedia.v3.api.player.VideoProgressUpdate;
+import com.uid2.EUIDManager;
 import com.uid2.UID2Manager;
 import com.uid2.data.UID2Identity;
 
@@ -227,7 +231,11 @@ public class MainActivity extends AppCompatActivity {
                 refreshExpires,
                 fromJsonIdentity.getRefreshResponseKey());
 
-            UID2Manager.getInstance().setIdentity(identity);
+            if (isEnvironmentEUID(getMetadata(getBaseContext()))) {
+                EUIDManager.getInstance().setIdentity(identity);
+            } else {
+                UID2Manager.getInstance().setIdentity(identity);
+            }
         } catch (Exception e) {
             Log.e(LOGTAG, "Error loading Identity: " + e);
         }

--- a/securesignals-ima-dev-app/src/main/java/com/uid2/dev/utils/BundleEx.kt
+++ b/securesignals-ima-dev-app/src/main/java/com/uid2/dev/utils/BundleEx.kt
@@ -1,0 +1,7 @@
+package com.uid2.dev.utils
+
+import android.os.Bundle
+
+private const val UID2_ENVIRONMENT_EUID = "uid2_environment_euid"
+
+fun Bundle.isEnvironmentEUID(): Boolean = getBoolean(UID2_ENVIRONMENT_EUID, false)

--- a/securesignals-ima-dev-app/src/main/java/com/uid2/dev/utils/ContextEx.kt
+++ b/securesignals-ima-dev-app/src/main/java/com/uid2/dev/utils/ContextEx.kt
@@ -1,0 +1,10 @@
+package com.uid2.dev.utils
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Bundle
+
+fun Context.getMetadata(): Bundle = packageManager.getApplicationInfoCompat(
+    packageName,
+    PackageManager.GET_META_DATA,
+).metaData

--- a/securesignals-ima-dev-app/src/main/java/com/uid2/dev/utils/PackageManagerEx.kt
+++ b/securesignals-ima-dev-app/src/main/java/com/uid2/dev/utils/PackageManagerEx.kt
@@ -1,0 +1,14 @@
+package com.uid2.dev.utils
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Build
+
+fun PackageManager.getApplicationInfoCompat(packageName: String, flags: Int = 0): ApplicationInfo =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        @Suppress("WrongConstant")
+        getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(flags.toLong()))
+    } else {
+        @Suppress("DEPRECATION")
+        getApplicationInfo(packageName, flags)
+    }

--- a/securesignals-ima/src/main/java/com/uid2/securesignals/ima/EUIDSecureSignalsAdapter.kt
+++ b/securesignals-ima/src/main/java/com/uid2/securesignals/ima/EUIDSecureSignalsAdapter.kt
@@ -1,0 +1,70 @@
+package com.uid2.securesignals.ima
+
+import android.content.Context
+import com.google.ads.interactivemedia.v3.api.VersionInfo
+import com.google.ads.interactivemedia.v3.api.signals.SecureSignalsAdapter
+import com.google.ads.interactivemedia.v3.api.signals.SecureSignalsCollectSignalsCallback
+import com.google.ads.interactivemedia.v3.api.signals.SecureSignalsInitializeCallback
+import com.uid2.EUIDManager
+import com.uid2.UID2
+
+/**
+ * A custom exception type that is used to report failures from the EUIDSecureSignalsAdapter when an error has occurred.
+ */
+public class EUIDSecureSignalsException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
+
+/**
+ * An implementation of Google's IMA SecureSignalsAdapter that integrates UID2 tokens, accessed via the UID2Manager.
+ */
+public class EUIDSecureSignalsAdapter : SecureSignalsAdapter {
+
+    /**
+     * Gets the version of the UID2 SDK.
+     */
+    public override fun getSDKVersion(): VersionInfo = UID2.getVersionInfo().let {
+        VersionInfo(it.major, it.minor, it.patch)
+    }
+
+    /**
+     * Gets the version of the UID2 Secure Signals plugin.
+     */
+    public override fun getVersion(): VersionInfo = PluginVersion.getVersionInfo().let {
+        VersionInfo(it.major, it.minor, it.patch)
+    }
+
+    /**
+     * Initialises the UID2 SDK with the given Context.
+     */
+    public override fun initialize(context: Context, callback: SecureSignalsInitializeCallback) {
+        // It's possible that the EUIDManager is already initialised. If so, it's a no-op.
+        if (!EUIDManager.isInitialized()) {
+            EUIDManager.init(context)
+        }
+
+        // After we've asked to initialize the manager, we should wait until it's complete before reporting success.
+        // This will potentially allow any previously persisted identity to be fully restored before we allow any
+        // signals to be collected.
+        EUIDManager.getInstance().addOnInitializedListener(callback::onSuccess)
+    }
+
+    /**
+     * Collects the UID2 advertising token, if available.
+     */
+    public override fun collectSignals(context: Context, callback: SecureSignalsCollectSignalsCallback) {
+        EUIDManager.getInstance().let { manager ->
+            val token = manager.getAdvertisingToken()
+            if (token != null) {
+                callback.onSuccess(token)
+            } else {
+                // We include the IdentityStatus in the "error" to have better visibility on why the Advertising Token
+                // was not present. There are a number of valid reasons why we don't have a token, but we are still
+                // required to report these as "failures".
+                callback.onFailure(
+                    EUIDSecureSignalsException(
+                        "No Advertising Token available (Status: ${manager.currentIdentityStatus.value})",
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/securesignals-ima/src/test/java/com/uid2/securesignals/ima/EUIDSecureSignalsAdapterTest.kt
+++ b/securesignals-ima/src/test/java/com/uid2/securesignals/ima/EUIDSecureSignalsAdapterTest.kt
@@ -1,0 +1,29 @@
+package com.uid2.securesignals.ima
+
+import com.uid2.UID2
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EUIDSecureSignalsAdapterTest {
+    @Test
+    fun `test SDK version`() {
+        val adapter = UID2SecureSignalsAdapter()
+        val version = adapter.sdkVersion
+        val expectedVersion = UID2.getVersionInfo()
+
+        assertEquals(expectedVersion.major, version.majorVersion)
+        assertEquals(expectedVersion.minor, version.minorVersion)
+        assertEquals(expectedVersion.patch, version.microVersion)
+    }
+
+    @Test
+    fun `test plugin version`() {
+        val adapter = UID2SecureSignalsAdapter()
+        val version = adapter.version
+        val expectedVersion = PluginVersion.getVersionInfo()
+
+        assertEquals(expectedVersion.major, version.majorVersion)
+        assertEquals(expectedVersion.minor, version.minorVersion)
+        assertEquals(expectedVersion.patch, version.microVersion)
+    }
+}


### PR DESCRIPTION
Implements `EUIDSecureSignalsAdapter`, essentially a clone of the UID2 adapter, but using the `EUIDManager` instance introduced in #98.

There is a new AndroidManifest meta-data key `uid2_environment_euid` for toggling the EUID environment in the dev app.

⚠️ Depends on #98.