### PR TITLE
Upgrade AGP 8.6.0 -> 8.7.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.6.0"
+agp = "8.7.1"
 kotlin = "2.0.0"
 core-ktx = "1.13.1"
 junit = "4.13.2"

--- a/sdk/src/main/java/com/uid2/UID2Manager.kt
+++ b/sdk/src/main/java/com/uid2/UID2Manager.kt
@@ -324,7 +324,7 @@ public class UID2Manager internal constructor(
     private suspend fun onInitialized() {
         initializedLock.withLock {
             while (onInitializedListeners.isNotEmpty()) {
-                onInitializedListeners.removeFirst().invoke()
+                onInitializedListeners.removeAt(0).invoke()
             }
         }
     }


### PR DESCRIPTION
Also addresses the following new lint error:

```
Error: This Kotlin extension function will be hidden by java.util.SequencedCollection starting in API 35 [NewApi]
                onInitializedListeners.removeFirst().invoke()
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```