### PR TITLE
Upgrade GMA and other dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,9 @@ junit = "4.13.2"
 appcompat = "1.7.0"
 coroutines-version = "1.10.1"
 compose = "1.10.1"
-compose-bom = "2025.02.00"
+compose-bom = "2025.03.00"
 compose-tooling = "1.7.8"
-gma = "23.6.0"
+gma = "24.1.0"
 ima = "3.36.0"
 mockkVersion = "1.13.17"
 prebid = "2.2.1"
@@ -58,4 +58,4 @@ kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.2" }
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }

--- a/securesignals-gma-dev-app/build.gradle
+++ b/securesignals-gma-dev-app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.uid2.securesignals.gma.devapp"
-        minSdk = 21
+        minSdk = 23
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
Upgrade GMA to 24.1.0. This requires a min-sdk bump for the GMA dev-app only.