### PR TITLE
Upgrade mockkk to 1.14.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ compose-bom = "2025.06.00"
 compose-tooling = "1.8.2"
 gma = "24.4.0"
 ima = "3.36.0"
-mockkVersion = "1.14.2"
+mockkVersion = "1.14.4"
 prebid = "2.2.1"
 ktlint = "1.0.1"
 

--- a/prebid/build.gradle
+++ b/prebid/build.gradle
@@ -20,11 +20,6 @@ android {
     kotlinOptions {
         freeCompilerArgs += [ "-opt-in=com.uid2.InternalUID2Api" ]
     }
-
-    lint {
-        warningsAsErrors = false
-        warning += 'Aligned16KB'
-    }
 }
 
 dependencies {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -34,11 +34,6 @@ android {
     kotlinOptions {
         freeCompilerArgs += [ "-opt-in=com.uid2.InternalUID2Api" ]
     }
-
-    lint {
-        warningsAsErrors = false
-        warning += 'Aligned16KB'
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Upgrade mockk and remove the gradle configuration disabling the 16kb alignment lint warning now that it is supported by mockk.