### PR TITLE
Upgrade to Prebid 3

### DIFF
--- a/dev-app/src/main/java/com/uid2/dev/DevApplication.kt
+++ b/dev-app/src/main/java/com/uid2/dev/DevApplication.kt
@@ -38,7 +38,7 @@ class DevApplication : Application() {
         // UID2Manager.init(this, INTEG_SERVER_URL, OkNetworkSession(), true)
 
         // Create the Prebid integration and allow it to start observing the UID2Manager instance.
-        PrebidMobile.initializeSdk(this) { Log.i(TAG, "Prebid: $it") }
+        PrebidMobile.initializeSdk(this, "") { Log.i(TAG, "Prebid: $it") }
         prebid = UID2Prebid(
             if (isEnvironmentEUID) EUIDManager.getInstance() else UID2Manager.getInstance(),
         ).apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.0"
+agp = "8.11.1"
 kotlin = "2.1.21"
 core-ktx = "1.16.0"
 junit = "4.13.2"
@@ -11,7 +11,7 @@ compose-tooling = "1.8.2"
 gma = "24.4.0"
 ima = "3.36.0"
 mockkVersion = "1.14.4"
-prebid = "2.2.1"
+prebid = "3.0.2"
 ktlint = "1.0.1"
 
 [libraries]

--- a/prebid/src/main/java/com/uid2/prebid/UID2Prebid.kt
+++ b/prebid/src/main/java/com/uid2/prebid/UID2Prebid.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.prebid.mobile.ExternalUserId
 import org.prebid.mobile.PrebidMobile
+import org.prebid.mobile.TargetingParams
 
 /**
  * Interface to wrap access to [PrebidMobile]. This is used to improve testability, rather than having the [UID2Prebid]
@@ -50,7 +51,7 @@ public class UID2Prebid internal constructor(
     ) : this(
         manager,
         externalUserIdFactory,
-        PrebidExternalUserIdInteractor { ids -> PrebidMobile.setExternalUserIds(ids) },
+        PrebidExternalUserIdInteractor { ids -> TargetingParams.setExternalUserIds(ids) },
         Dispatchers.Default,
     )
 
@@ -121,12 +122,18 @@ public class UID2Prebid internal constructor(
      */
     private fun String.toExternalUserIdList(): List<ExternalUserId> {
         return listOf(
-            ExternalUserId(USER_ID_SOURCE, this, null, null),
+            ExternalUserId(USER_ID_SOURCE, listOf(ExternalUserId.UniqueId(this, AGENT_TYPE_PERSON_ID))),
         )
     }
 
     private companion object {
         const val TAG = "UID2Prebid"
         const val USER_ID_SOURCE = "uidapi.com"
+
+        /**
+         * "A person-based ID, i.e., that is the same across devices."
+         * https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list_agenttypes
+         */
+        const val AGENT_TYPE_PERSON_ID = 3
     }
 }

--- a/prebid/src/test/java/com/uid2/prebid/UID2PrebidTest.kt
+++ b/prebid/src/test/java/com/uid2/prebid/UID2PrebidTest.kt
@@ -58,7 +58,7 @@ class UID2PrebidTest {
 
         // Verify that immediately after being initialized, the available advertising token is set on Prebid.
         assertEquals(1, prebidExternalUserIdInteractor.lastIds.size)
-        assertEquals(currentAdvertisingToken, prebidExternalUserIdInteractor.lastIds[0].identifier)
+        assertEquals(currentAdvertisingToken, prebidExternalUserIdInteractor.lastIds[0].uniqueIds[0].id)
     }
 
     @Test
@@ -151,9 +151,11 @@ class UID2PrebidTest {
     private fun FakePrebidExternalUserIdInteractor.assertLastToken(advertisingToken: String) {
         assertTrue(lastIds.isNotEmpty())
         lastIds.last().let {
-            assertEquals(advertisingToken, it.identifier)
             assertEquals("uidapi.com", it.source)
-            assertNull(it.atype)
+            assertEquals(1, it.uniqueIds.size)
+            val id = it.uniqueIds[0]
+            assertEquals(advertisingToken, id.id)
+            assertEquals(3, id.atype)
             assertNull(it.ext)
         }
     }


### PR DESCRIPTION
Upgrade to Prebid 3, which includes some [breaking changes](https://docs.prebid.org/prebid-mobile/updates-3.0/android/api-changes.html) in how external IDs (the UID2) are set.

Agent type (`aType`) is now a required parameter. use the value `3` which matches the UID2 iOS implementation, and indicates  ["A person-based ID, i.e., that is the same across devices."](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list_agenttypes).