### PR TITLE
UID2-6913: Pin third-party GitHub Action refs to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@cca926ef8d60d59c0bc5b36cfe99255048accd88 # v4
 
       - name: Build and run tests
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,10 @@ jobs:
           git config --local user.email IABTechLab@users.noreply.github.com
 
       - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@cca926ef8d60d59c0bc5b36cfe99255048accd88 # v4
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@cca926ef8d60d59c0bc5b36cfe99255048accd88 # v4
 
       - name: Get Snapshot versions
         id: snapshotVersions
@@ -112,7 +112,7 @@ jobs:
           rm gradle.properties.bak
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           generate_release_notes: true
           tag_name: v${{ steps.validation.outputs.release_version }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.0"
+agp = "9.0.1"
 kotlin = "2.1.21"
 core-ktx = "1.16.0"
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "9.1.1"
 kotlin = "2.1.21"
 core-ktx = "1.16.0"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
Pin third-party (non-GitHub-owned) action references to full-length commit SHAs to mitigate supply-chain attacks from mutable tags.

Only external actions are pinned in this PR (e.g. `docker/*`, `aws-actions/*`, `softprops/*`, etc.). GitHub-owned actions (`actions/*`) are not included in this change.

## Verification
Each SHA can be verified with:
```
git ls-remote https://github.com/<owner>/<repo> <tag>
```

## Test plan
- [ ] Verify CI passes with pinned refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)