### PR TITLE
UID2-7263 Skip SNAPSHOT publishing in Android SDK build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,14 @@ jobs:
         with:
             scan_type: 'fs'
 
-      - name: Deploy SNAPSHOT to Maven Central
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Read version name
+        id: version
+        run: echo "name=$(grep '^VERSION_NAME=' gradle.properties | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+
+      # The Sonatype Central Portal (SONATYPE_HOST=CENTRAL_PORTAL) does not support
+      # SNAPSHOT publishing, so skip this step for -SNAPSHOT versions to avoid a 403.
+      - name: Deploy to Maven Central
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !endsWith(steps.version.outputs.name, '-SNAPSHOT')
         run: ./gradlew publish --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_SONATYPE_REPO_USERNAME }}


### PR DESCRIPTION
## Summary

The `build.yml` "Deploy to Maven Central" step runs `./gradlew publish` on every push to `main`. The project is configured with `SONATYPE_HOST=CENTRAL_PORTAL` (`gradle.properties`), which routes publishes to `central.sonatype.com`. The Sonatype Central Portal **does not support SNAPSHOT publishing** — with the current `VERSION_NAME=2.2.0-SNAPSHOT`, the step fails with a `403 Forbidden` on every push to `main`.

## Change

- Added a `Read version name` step that extracts `VERSION_NAME` from `gradle.properties` into a step output.
- Gated the publish step with `!endsWith(steps.version.outputs.name, '-SNAPSHOT')` so it only runs for release (non-SNAPSHOT) versions.
- Renamed the step from "Deploy SNAPSHOT to Maven Central" to "Deploy to Maven Central" to reflect that it now only publishes releases.

## Acceptance criteria

- [x] Pushes to `main` no longer fail due to the SNAPSHOT publish step (step is now skipped for `-SNAPSHOT`)
- [x] Release (non-SNAPSHOT) versions are still published via the workflow (condition allows them through)

## References

- Jira: [UID2-7263](https://thetradedesk.atlassian.net/browse/UID2-7263)
- Failed CI run: [actions/runs/27187967308](https://github.com/IABTechLab/uid2-android-sdk/actions/runs/27187967308)

🤖 Generated with [Claude Code](https://claude.com/claude-code)